### PR TITLE
🐛 Fixed player searching process (Removed duplicated results)

### DIFF
--- a/src/components/SystemSettings/General/OwnerSetter/InputFieldView.vue
+++ b/src/components/SystemSettings/General/OwnerSetter/InputFieldView.vue
@@ -3,6 +3,9 @@ import SsInput from 'src/components/util/base/ssInput.vue';
 import { usePlayerStore } from 'src/stores/WorldTabs/PlayerStore';
 
 const playerStore = usePlayerStore()
+
+// ページを読み込んだ時に検索欄をリセット
+playerStore.searchName = ''
 </script>
 
 <template>

--- a/src/components/SystemSettings/General/OwnerSetter/SearchResultView.vue
+++ b/src/components/SystemSettings/General/OwnerSetter/SearchResultView.vue
@@ -42,6 +42,8 @@ function setOwner(player: Player) {
                 Object.values(playerStore.cachePlayers)
               ).sort(
                 (a, b) => strSort(a.name, b.name)
+              ).filter(
+                v => playerStore.newPlayerCandidate?.name !== v.name
               )"
             :key="p"
           >

--- a/src/components/World/Player/SearchResultView.vue
+++ b/src/components/World/Player/SearchResultView.vue
@@ -60,6 +60,8 @@ function hasPlayerInWorld(playerUUID?: PlayerUUID) {
               filterRegisteredPlayer(Object.values(playerStore.cachePlayers))
             ).sort(
               (a, b) => strSort(a.name, b.name)
+            ).filter(
+              v => playerStore.newPlayerCandidate?.name !== v.name
             )"
           :key="p"
         >

--- a/src/pages/WorldTabs/PlayerPage.vue
+++ b/src/pages/WorldTabs/PlayerPage.vue
@@ -21,6 +21,9 @@ import GroupEditorView from 'src/components/World/Player/GroupEditorView.vue';
 const mainStore = useMainStore()
 const playerStore = usePlayerStore()
 
+// ページを読み込んだ時に検索欄をリセット
+playerStore.searchName = ''
+
 const orderTypes = ['name', 'op'] as const
 const playerOrder: Ref<(typeof orderTypes)[number]> = ref('name')
 function playerSortFunc(orderType: (typeof orderTypes)[number]): (a: PlayerSetting, b: PlayerSetting) => number {


### PR DESCRIPTION
# プレイヤー検索機能の修正

- プレイヤータグとオーナー設定において、検索実績のあるプレイヤーのフルネームが入力されたときに、当該プレイヤーが２重に表示される問題を修正

- プレイヤータグまたはオーナー設定において、入力欄に任意の文字を入力した状態で他方の画面へ移動すると、文字が入力されたままになっている問題を修正