### PR TITLE
🩹 Fixed animation speed

### DIFF
--- a/src/components/Error/ErrorDialogView.vue
+++ b/src/components/Error/ErrorDialogView.vue
@@ -18,7 +18,7 @@ closeCounter()
 function closeCounter() {
   // ホバー中はカウントを進めない
   if (!hovered.value) {
-    timeCounter.value += 0.007
+    timeCounter.value += 0.02
   }
 
   // カウンターの進行 or Dialogを閉じる


### PR DESCRIPTION
# エラーダイアログの表示時間を修正

- エラーダイアログの表示時間を14秒から５秒に短縮

- ダイアログホバー時にカウントダウンがストップする仕様変更に伴う修正漏れ