### PR TITLE
色設定を修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 import { toRaw, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
-import { setCssVar, useQuasar } from 'quasar';
+import { useQuasar } from 'quasar';
 import { $T, setI18nFunc, tError } from './i18n/utils/tFunc';
 import { useConsoleStore } from './stores/ConsoleStore';
 import { initSystemSettings, useSystemStore, setSysSettingsSubscriber } from './stores/SystemStore';
@@ -13,6 +13,7 @@ import { checkError, setOpenDialogFunc } from 'src/components/Error/Error';
 import { setShutdownHandler } from './components/SystemSettings/General/AutoShutdown/AutoShutdown';
 import { EulaDialogProp } from 'src/components/Progress/iEulaDialog';
 import { deepCopy } from './scripts/deepCopy';
+import { setColor } from './color';
 import ErrorDialogView from './components/Error/ErrorDialogView.vue'
 import EulaDialog from 'src/components/Progress/EulaDialog.vue';
 
@@ -36,7 +37,7 @@ $q.dark.set('auto');
 
 // primaryの色を定義
 watch(() => $q.dark.isActive, val => {
-  setPrimary(val)
+  setColor(val, sysStore.systemSettings.user.visionSupport)
 })
 
 // サーバー起動時に画面遷移
@@ -101,7 +102,7 @@ async function setUserSettings() {
   $q.dark.set(isAuto ? 'auto' : isDark)
 
   // primaryの色を定義
-  setPrimary($q.dark.isActive)
+  setColor($q.dark.isActive, sysStore.systemSettings.user.visionSupport)
 }
 
 /**
@@ -140,18 +141,6 @@ function setSubscribe() {
   setSysSettingsSubscriber()
 
   setPlayerSearchSubscriber(playerStore)
-}
-
-/**
- * primaryの色を定義
- */
-function setPrimary(isDark: boolean) {
-  if (isDark) {
-    setCssVar('primary', '#7FFF00')
-  }
-  else {
-    setCssVar('primary', '#1EB000')
-  }
 }
 </script>
 

--- a/src/color/colors.ts
+++ b/src/color/colors.ts
@@ -22,6 +22,3 @@ export const colors: ColorSettings = {
     primary: '#1E8FFF'
   }
 }
-
-
-// TODO: text-red -> text-negativeに変更する

--- a/src/color/colors.ts
+++ b/src/color/colors.ts
@@ -1,0 +1,27 @@
+type ColorSetting = {
+  primary: string
+}
+
+export type ColorThemes = 'light' | 'dark' | 'light-diversity' | 'dark-diversity'
+
+type ColorSettings = {
+  [key in ColorThemes]: ColorSetting
+}
+
+export const colors: ColorSettings = {
+  'light': {
+    primary: '#1EB000',
+  },
+  'dark': {
+    primary: '#7FFF00'
+  },
+  'light-diversity': {
+    primary: '#0032D4'
+  },
+  'dark-diversity': {
+    primary: '#1E8FFF'
+  }
+}
+
+
+// TODO: text-red -> text-negativeに変更する

--- a/src/color/index.ts
+++ b/src/color/index.ts
@@ -1,0 +1,30 @@
+import { setCssVar } from "quasar";
+import { keys } from "src/scripts/obj";
+import { ColorThemes, colors } from "./colors";
+
+export function setColor(isDark: boolean, isDiversity: boolean) {
+  const pattern = Number(isDark) + Number(isDiversity) * 2
+
+  switch (pattern) {
+    case 0:
+      setCss('light')
+      break;
+    case 1:
+      setCss('dark')
+      break;
+    case 2:
+      setCss('light-diversity')
+      break;
+    case 3:
+      setCss('dark-diversity')
+      break;
+    default:
+      break;
+  }
+}
+
+function setCss(theme: ColorThemes) {
+  keys(colors[theme]).forEach(
+    k => setCssVar(k, colors[theme][k])
+  )
+}

--- a/src/components/Progress/EulaDialog.vue
+++ b/src/components/Progress/EulaDialog.vue
@@ -6,7 +6,7 @@ import SsA from '../util/base/ssA.vue';
 import SsBtn from '../util/base/ssBtn.vue';
 
 defineProps<EulaDialogProp>()
-defineEmits({...useDialogPluginComponent.emitsObject})
+defineEmits({ ...useDialogPluginComponent.emitsObject })
 const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent()
 </script>
 
@@ -17,18 +17,18 @@ const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginC
       :okBtnTxt="$t('eulaDialog.agree')"
       @okClick="onDialogOK"
     >
-      <template #default>        
+      <template #default>
         <p class="q-my-none" style="font-size: .8rem; opacity: .8;">
           <i18n-t keypath="eulaDialog.desc" tag="label">
             <SsA :url="eulaURL">{{ $t('eulaDialog.eula') }}</SsA>
             <br>
-      </i18n-t>
+          </i18n-t>
         </p>
       </template>
       <template #additionalBtns>
         <SsBtn
           :label="$t('eulaDialog.disagree')"
-          color="red"
+          color="negative"
           @click="onDialogCancel"
         />
       </template>

--- a/src/components/SystemSettings/Folder/AddFolderDialog.vue
+++ b/src/components/SystemSettings/Folder/AddFolderDialog.vue
@@ -12,7 +12,7 @@ import SsInput from 'src/components/util/base/ssInput.vue';
 import SsBtn from 'src/components/util/base/ssBtn.vue';
 
 const prop = defineProps<AddFolderDialogProps>()
-defineEmits({...useDialogPluginComponent.emitsObject})
+defineEmits({ ...useDialogPluginComponent.emitsObject })
 const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent()
 
 const sysStore = useSystemStore()
@@ -24,7 +24,7 @@ async function pickFolder() {
   checkError(
     res,
     c => pickPath.value = c,
-    e => tError(e, {ignoreErrors:['data.path.dialogCanceled']})
+    e => tError(e, { ignoreErrors: ['data.path.dialogCanceled'] })
   )
 }
 
@@ -49,18 +49,15 @@ function isErrorContainer(c: WorldContainerSetting) {
 <template>
   <q-dialog ref="dialogRef" @hide="onDialogHide">
     <BaseDialogCard
-      :title="
-        containerSettings === void 0
-          ? $t('home.saveWorld.addFolder')
-          : $t('home.saveWorld.updateFolder')"
-      :disable="
-        sysStore.systemSettings.container.filter(isErrorContainer).length > 0
-          || inputName === ''
-          || pickPath === ''"
-      :ok-btn-txt="
-        inputName
-         ? $t('home.saveWorld.addBtn', { name: inputName })
-         : $t('home.saveWorld.add')"
+      :title="containerSettings === void 0
+        ? $t('home.saveWorld.addFolder')
+        : $t('home.saveWorld.updateFolder')"
+      :disable="sysStore.systemSettings.container.filter(isErrorContainer).length > 0
+        || inputName === ''
+        || pickPath === ''"
+      :ok-btn-txt="inputName
+        ? $t('home.saveWorld.addBtn', { name: inputName })
+        : $t('home.saveWorld.add')"
       @ok-click="onDialogOK({ name: inputName, container: pickPath } as AddFolderDialogReturns)"
       @close="onDialogCancel"
     >
@@ -77,32 +74,32 @@ function isErrorContainer(c: WorldContainerSetting) {
           @click="pickFolder"
         />
       </div>
-      
+
       <div
         v-if="sysStore.systemSettings.container.filter(isErrorName).length > 0"
-        class="text-caption text-omit text-red q-pt-sm"
+        class="text-caption text-omit text-negative q-pt-sm"
       >
-        {{ $t('home.saveWorld.exist',{ name: inputName }) }}
+        {{ $t('home.saveWorld.exist', { name: inputName }) }}
       </div>
       <div
         v-if="sysStore.systemSettings.container.filter(isErrorPath).length > 0"
-        class="text-caption text-omit text-red q-pt-sm"
+        class="text-caption text-omit text-negative q-pt-sm"
       >
-          {{ $t('home.saveWorld.registered', omitPath({ 'path': pickPath })) }}
+        {{ $t('home.saveWorld.registered', omitPath({ 'path': pickPath })) }}
       </div>
       <div
         v-if="inputName === ''"
-        class="text-caption text-omit text-red q-pt-sm"
+        class="text-caption text-omit text-negative q-pt-sm"
       >
         {{ $t('home.saveWorld.inputFolderName') }}
       </div>
       <div
         v-if="pickPath === ''"
-        class="text-caption text-omit text-red q-pt-sm"
+        class="text-caption text-omit text-negative q-pt-sm"
       >
         {{ $t('home.saveWorld.selectFolder') }}
       </div>
-      <div 
+      <div
         v-if="pickPath !== ''"
         class="text-caption text-omit q-pt-sm"
         style="opacity: .6;"

--- a/src/components/SystemSettings/Folder/FolderCard.vue
+++ b/src/components/SystemSettings/Folder/FolderCard.vue
@@ -53,8 +53,8 @@ function removeFolder() {
   $q.dialog({
     component: DangerDialog,
     componentProps: {
-      dialogTitle: t('systemsetting.folder.unregistTitle',{ name: folder.value.name }),
-      dialogDesc: t('systemsetting.folder.unregistDialog',{ name: folder.value.name }),
+      dialogTitle: t('systemsetting.folder.unregistTitle', { name: folder.value.name }),
+      dialogDesc: t('systemsetting.folder.unregistDialog', { name: folder.value.name }),
       okBtnTxt: t('systemsetting.folder.unregist')
     } as dangerDialogProp
   }).onOk(() => {
@@ -73,18 +73,14 @@ function removeFolder() {
     :style="{ 'border-color': active ? getCssVar('primary') : 'transparent' }"
   >
     <div class="row">
-      <div
-        class="col q-pl-md q-py-md"
-        :class="getCardSytleClass(active, disable || loading)"
-        style="margin: auto 0;"
-      >
+      <div class="col q-pl-md q-py-md" :class="getCardSytleClass(active, disable || loading)" style="margin: auto 0;">
         <div class="text-omit" style="font-size: 1.1rem;">{{ folder.name }}</div>
         <div class="text-caption text-omit" style="opacity: .6;">{{ folder.container }}</div>
       </div>
 
       <!-- cardをクリックできるようにする -->
       <div v-if="onClick !== void 0 || !disable" class="absolute-top fit">
-        <q-btn flat color="transparent" @click="onClick" class="fit"/>
+        <q-btn flat color="transparent" @click="onClick" class="fit" />
       </div>
 
       <div class="row q-gutter-x-sm q-pr-md" style="margin: auto 0;">
@@ -110,7 +106,7 @@ function removeFolder() {
           v-show="showOperationBtns"
           free-width
           :label="$t('systemsetting.folder.unregist')"
-          color="red"
+          color="negative"
           :disable="sysStore.systemSettings.container.length === 1 || disable"
           @click="removeFolder"
         />

--- a/src/components/SystemSettings/Remote/github/GithubCard.vue
+++ b/src/components/SystemSettings/Remote/github/GithubCard.vue
@@ -84,7 +84,7 @@ function checkUnlinkRepo() {
         v-if="showUnlink"
         :disable="disable"
         :label="$t('shareWorld.githubCard.unregister.remote')"
-        color="red"
+        color="negative"
         @click="checkUnlinkRepo"
       />
       <SsBtn

--- a/src/components/World/Console/OperationView.vue
+++ b/src/components/World/Console/OperationView.vue
@@ -31,7 +31,7 @@ async function reboot() {
       is-capital
       icon="stop"
       :label="$t('console.stop')"
-      color="red"
+      color="negative"
       width="100px"
       :disable="disable"
       @click="stop"

--- a/src/components/World/Console/RunningView.vue
+++ b/src/components/World/Console/RunningView.vue
@@ -40,7 +40,7 @@ consoleStore.$subscribe((mutation, state) => {
     class="q-pa-md fit"
     style="flex: 1 1 0;"
   >
-    <p :class="item.isError ? 'text-red' : ''" style="word-break:break-all;">
+    <p :class="item.isError ? 'text-negative' : ''" style="word-break:break-all;">
       {{ item.chunk }}
     </p>
   </q-virtual-scroll>

--- a/src/components/World/Contents/ContentsView.vue
+++ b/src/components/World/Contents/ContentsView.vue
@@ -39,23 +39,23 @@ async function importNewContent(isFile = false) {
       // TODO: 何もファイルを選択せずに修了した場合もエラー扱いとなるため、
       // 何も選択しなかった場合はエラーを表示せず、不適なファイルが選択された際には適切なエラーを表示するようにする
       checkError(
-        await window.API.invokePickDialog({type: 'datapack', isFile: isFile}),
+        await window.API.invokePickDialog({ type: 'datapack', isFile: isFile }),
         c => addContent2World(c),
-        e => tError(e, {ignoreErrors:['data.path.dialogCanceled']})
+        e => tError(e, { ignoreErrors: ['data.path.dialogCanceled'] })
       )
       break;
     case 'plugin':
       checkError(
-        await window.API.invokePickDialog({type: 'plugin'}),
+        await window.API.invokePickDialog({ type: 'plugin' }),
         c => addContent2World(c),
-        e => tError(e, {ignoreErrors:['data.path.dialogCanceled']})
+        e => tError(e, { ignoreErrors: ['data.path.dialogCanceled'] })
       )
       break;
     case 'mod':
       checkError(
-        await window.API.invokePickDialog({type: 'mod'}),
+        await window.API.invokePickDialog({ type: 'mod' }),
         c => addContent2World(c),
-        e => tError(e, {ignoreErrors:['data.path.dialogCanceled']})
+        e => tError(e, { ignoreErrors: ['data.path.dialogCanceled'] })
       )
       break;
     default:
@@ -102,10 +102,15 @@ function openCacheFolder() {
 
 <template>
   <div class="q-px-md">
-    <h1 class="q-py-xs">{{ $t('additionalContents.management', { type: $t(`additionalContents.${prop.contentType}` )}) }}</h1>
+    <h1 class="q-py-xs">{{ $t('additionalContents.management', { type: $t(`additionalContents.${prop.contentType}`) }) }}
+    </h1>
 
-    <span class="text-caption">{{ $t('additionalContents.installed', { type: $t(`additionalContents.${prop.contentType}` ) }) }}</span>
-    <p v-if="consoleStore.status(mainStore.world.id) !== 'Stop' && contentType !== 'datapack'" class="text-caption text-red q-ma-none">
+    <span class="text-caption">
+      {{ $t('additionalContents.installed', { type: $t(`additionalContents.${prop.contentType}`) }) }}
+    </span>
+    <p v-if="consoleStore.status(mainStore.world.id) !== 'Stop' && contentType !== 'datapack'"
+      class="text-caption text-negative q-ma-none"
+    >
       {{ $t('additionalContents.needReboot') }}
     </p>
     <div class="row q-gutter-md q-pa-sm">
@@ -116,7 +121,7 @@ function openCacheFolder() {
       </template>
       <div v-else class="full-width">
         <p class="q-my-lg text-center text-h5" style="opacity: .6;">
-          {{ $t('additionalContents.notInstalled', { type: $t(`additionalContents.${prop.contentType}` )}) }}
+          {{ $t('additionalContents.notInstalled', { type: $t(`additionalContents.${prop.contentType}`) }) }}
         </p>
       </div>
     </div>
@@ -124,7 +129,9 @@ function openCacheFolder() {
     <q-separator class="q-my-md" />
 
     <div class="row justify-between">
-      <span class="text-caption">{{ $t('additionalContents.add', { type: $t(`additionalContents.${prop.contentType}` ) }) }}</span>
+      <span class="text-caption">
+        {{ $t('additionalContents.add', { type: $t(`additionalContents.${prop.contentType}`) }) }}
+      </span>
       <q-btn
         dense
         flat

--- a/src/components/World/Contents/itemCardView.vue
+++ b/src/components/World/Contents/itemCardView.vue
@@ -47,13 +47,14 @@ function deleteContent() {
             dense
             flat
             stack
-            color="red"
+            color="negative"
             icon="close"
             size="1rem"
             @click="deleteContent"
           >
-            <div class="text-red text-center full-width" style="font-size: .8rem;">
-              {{ $t('general.delete') }}</div>
+            <div class="text-negative text-center full-width" style="font-size: .8rem;">
+              {{ $t('general.delete') }}
+            </div>
           </q-btn>
         </q-item-section>
         <q-item-section v-else side>

--- a/src/components/World/HeaderView.vue
+++ b/src/components/World/HeaderView.vue
@@ -8,7 +8,7 @@ const mainStore = useMainStore()
 const consoleStore = useConsoleStore()
 
 const statusColor = {
-  'Stop': 'red',
+  'Stop': 'negative',
   'Ready': 'grey',
   'Running': 'primary'
 }

--- a/src/components/World/Player/GroupEditorView.vue
+++ b/src/components/World/Player/GroupEditorView.vue
@@ -23,7 +23,7 @@ function validateGroupName(name: string) {
   return name !== '' && !(name !== playerStore.selectedGroupName && keys(playerStore.searchGroups()).includes(name))
 }
 function validateMessage(name: string) {
-  return name !== '' ? t('player.groupNameDuplicate',{group: name}) : t('player.insertGroupName')
+  return name !== '' ? t('player.groupNameDuplicate', { group: name }) : t('player.insertGroupName')
 }
 
 /**
@@ -123,8 +123,13 @@ function removeGroup() {
       <q-separator v-show="!playerStore.selectedGroup.isNew" inset />
 
       <q-card-section v-show="!playerStore.selectedGroup.isNew">
-        <q-btn outline :label="$t('player.deleteGroup', { group: playerStore.selectedGroupName })" color="red"
-          @click="removeGroup" class="full-width" />
+        <q-btn
+          outline
+          :label="$t('player.deleteGroup', { group: playerStore.selectedGroupName })"
+          color="negative"
+          @click="removeGroup"
+          class="full-width"
+        />
       </q-card-section>
     </q-scroll-area>
   </q-card>

--- a/src/components/World/Player/OpSetterView.vue
+++ b/src/components/World/Player/OpSetterView.vue
@@ -35,7 +35,7 @@ function setOP(setVal: 0 | OpLevel) {
   else {
     setter({ level: setVal, bypassesPlayerLimit: false })
   }
-  
+
   // フォーカスのリセット
   playerStore.unFocus()
 }
@@ -60,8 +60,10 @@ function removePlayer() {
     class="column"
     style="width: 13rem; height: 325px; max-height: 45vh;"
   >
-    <p class="q-pa-sm q-ma-none text-body2">{{ $t('player.editPlayer',{n: playerStore.focusCards.size}) }}</p>
-    
+    <p class="q-pa-sm q-ma-none text-body2">
+      {{ $t('player.editPlayer', { n: playerStore.focusCards.size }) }}
+    </p>
+
     <q-scroll-area style="flex: 1 1 0;">
       <template v-for="opLevel in ([4, 3, 2, 1, 0] as const)" :key="opLevel">
         <OpLevelBtn
@@ -72,12 +74,7 @@ function removePlayer() {
         />
       </template>
       <q-separator inset class="q-mt-xs" />
-      <OpLevelBtn
-        icon="close"
-        :label="$t('player.deletePlayer')"
-        color="red"
-        @click="removePlayer"
-      />
+      <OpLevelBtn icon="close" :label="$t('player.deletePlayer')" color="negative" @click="removePlayer" />
     </q-scroll-area>
   </q-card>
 </template>

--- a/src/components/World/Property/SettingBlockView.vue
+++ b/src/components/World/Property/SettingBlockView.vue
@@ -27,29 +27,27 @@ function cancelSettings() {
 
     <q-item-section>
       <div class="text-h6">{{ settingName }}</div>
-      <div class="text-caption" style="opacity: .5;">{{ $t(`property.description['${settingName}']`, $t('property.description.notFound')) }}</div>
+      <div class="text-caption" style="opacity: .5;">
+        {{ $t(`property.description['${settingName}']`, $t('property.description.notFound')) }}
+      </div>
       <InputFieldView v-model="propertiesModel" :property-name="settingName" />
     </q-item-section>
 
     <q-item-section v-show="$router.currentRoute.value.path !== '/system/property'" side>
-      <q-btn 
-        v-show="propertiesModel[settingName].toString() !== defaultProperty.toString()" 
-        flat 
+      <q-btn
+        v-show="propertiesModel[settingName].toString() !== defaultProperty.toString()"
+        flat
         dense
-        icon="do_not_disturb_on" 
-        size="1rem" 
-        color="red" 
+        icon="do_not_disturb_on"
+        size="1rem"
+        color="negative"
         @click="cancelSettings"
-        >
+      >
         <q-tooltip>
-          <p 
-            class="text-caption q-ma-none"
-            v-html = "$t('property.resetProperty', { defaultProperty: defaultProperty })"
-          />
+          <p class="text-caption q-ma-none" v-html="$t('property.resetProperty', { defaultProperty: defaultProperty })" />
         </q-tooltip>
       </q-btn>
     </q-item-section>
-
   </q-item>
 </template>
 

--- a/src/components/World/ShareWorld/selecters/github/NewGitHubDialog.vue
+++ b/src/components/World/ShareWorld/selecters/github/NewGitHubDialog.vue
@@ -8,7 +8,7 @@ import BaseDialogCard from 'src/components/util/baseDialog/baseDialogCard.vue';
 import SsInput from 'src/components/util/base/ssInput.vue';
 import { useI18n } from 'vue-i18n';
 
-defineEmits({...useDialogPluginComponent.emitsObject})
+defineEmits({ ...useDialogPluginComponent.emitsObject })
 const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent()
 const prop = defineProps<GithubCheckDialogProp>()
 
@@ -66,7 +66,7 @@ async function setRemote() {
         <i18n-t keypath="shareWorld.newRemote.desc" tag="false">
           <br>
           <br>
-          <span class="text-red text-bold">{{ $t('shareWorld.newRemote.caution') }}</span>
+          <span class="text-negative text-bold">{{ $t('shareWorld.newRemote.caution') }}</span>
         </i18n-t>
       </p>
 

--- a/src/components/util/danger/DangerDialog.vue
+++ b/src/components/util/danger/DangerDialog.vue
@@ -13,7 +13,7 @@ const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginC
     <BaseDialogCard
       :overline="dialogOverline"
       :title="dialogTitle"
-      color="red"
+      color="negative"
       :ok-btn-txt="okBtnTxt"
       @ok-click="onDialogOK"
       @close="onDialogCancel"

--- a/src/components/util/danger/dangerView.vue
+++ b/src/components/util/danger/dangerView.vue
@@ -32,12 +32,12 @@ function openDialog() {
 
 <template>
   <div class="q-py-lg">
-    <h1 class="q-pt-sm text-red">{{ viewTitle }}</h1>
-    <p v-html="viewDesc" class="text-caption q-py-sm"/>
+    <h1 class="q-pt-sm text-negative">{{ viewTitle }}</h1>
+    <p v-html="viewDesc" class="text-caption q-py-sm" />
     <SsBtn
       :label="openDialogBtnText"
       :disable="disable"
-      color="red"
+      color="negative"
       @click="openDialog"
     />
   </div>

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -12,13 +12,11 @@
 // to match your app's branding.
 // Tip: Use the "Theme Builder" on Quasar's documentation website.
 
-$red: #FF3434;
-
 $primary   : #7CBB00;
 $secondary : #26A69A;
 $accent    : #9C27B0;
 
 $positive  : #21BA45;
-$negative  : #C10015;
+$negative  : #FF3434;
 $info      : #31CCEC;
 $warning   : #F2C037;

--- a/src/i18n/en-US/systemsetting.ts
+++ b/src/i18n/en-US/systemsetting.ts
@@ -6,6 +6,8 @@ export const enUSSystemSetting: MessageSchema['systemsetting'] = {
     lang: 'Language',
     langDesc: 'Select your language',
     colorMode: 'Appearance',
+    useVisionSupport : 'Apply vision support',
+    noVisionSupport: 'Don\'t apply vision support',
     autoShutdown: 'Auto-Shutdown',
     shutdownDesc: 'Allow to shutdown your PC after you close the server',
   },

--- a/src/i18n/ja/systemsetting.ts
+++ b/src/i18n/ja/systemsetting.ts
@@ -4,6 +4,8 @@ export const jaSystemSetting = {
     lang: '言語',
     langDesc: '言語を選択してください',
     colorMode: '配色モード',
+    useVisionSupport: '色覚補正を適用する',
+    noVisionSupport: '色覚補正を適用しない',
     autoShutdown: '自動シャットダウン',
     shutdownDesc: 'サーバー終了後に自動でPCをシャットダウンする',
   },

--- a/src/pages/ErrorPage.vue
+++ b/src/pages/ErrorPage.vue
@@ -17,16 +17,16 @@ function closeWindow() {
     <q-card flat class="bg-transparent">
       <q-card-section horizontal>
         <q-card-section class="col-2 flex flex-center">
-          <q-icon name="warning" color="orange" size="5rem"/>
+          <q-icon name="warning" color="orange" size="5rem" />
         </q-card-section>
-    
+
         <q-card-section>
           <div>
             <p>{{ $t('utils.bugReport.title') }}</p>
             <p style="text-decoration: underline;">{{ store.description }}</p>
             <p v-html="$t('utils.bugReport.desc')"></p>
           </div>
-    
+
           <div>
             <p>{{ $t('utils.bugReport.cause') }}</p>
             <p>{{ store.error }}</p>
@@ -36,9 +36,29 @@ function closeWindow() {
 
       <q-card-actions class="justify-center">
         <!-- TODO: バグ報告フォームの整備 -->
-        <q-btn color="red" icon="pest_control" :label="$t('utils.bugReport.reportBtn')" size="1.3rem" class="q-mx-md"/>
-        <q-btn color="blue-1" text-color="blue" icon="img:https://cdn.iconscout.com/icon/free/png-512/free-twitter-87-432551.png?f=avif&w=256" :label="$t('utils.bugReport.contact')" size="1.3rem" class="q-mx-md" @click="showTwitter"/>
-        <q-btn icon="close" :label="$t('utils.bugReport.close')" size="1.3rem" class="q-mx-md" @click="closeWindow"/>
+        <q-btn
+          color="negative"
+          icon="pest_control"
+          :label="$t('utils.bugReport.reportBtn')"
+          size="1.3rem"
+          class="q-mx-md"
+        />
+        <q-btn
+          color="blue-1"
+          text-color="blue"
+          icon="img:https://cdn.iconscout.com/icon/free/png-512/free-twitter-87-432551.png?f=avif&w=256"
+          :label="$t('utils.bugReport.contact')"
+          size="1.3rem"
+          class="q-mx-md"
+          @click="showTwitter"
+        />
+        <q-btn
+          icon="close"
+          :label="$t('utils.bugReport.close')"
+          size="1.3rem"
+          class="q-mx-md"
+          @click="closeWindow"
+        />
       </q-card-actions>
     </q-card>
   </div>

--- a/src/pages/SystemSettings/FolderPage.vue
+++ b/src/pages/SystemSettings/FolderPage.vue
@@ -29,12 +29,15 @@ function openFolderEditor() {
     <p class="q-my-sm text-body2" style="opacity: .6;">
       {{ $t('home.saveWorld.description') }}
     </p>
-    <p v-if="!consoleStore.isAllWorldStop()" class="q-my-sm text-body2 text-red">
+    <p v-if="!consoleStore.isAllWorldStop()" class="q-my-sm text-body2 text-negative">
       {{ $t('home.saveWorld.cannotEdit') }}
     </p>
 
     <div class="column q-py-sm q-gutter-y-md">
-      <template v-for="n in sysStore.systemSettings.container.length" :key="sysStore.systemSettings.container[n-1]">
+      <template
+        v-for="n in sysStore.systemSettings.container.length"
+        :key="sysStore.systemSettings.container[n-1]"
+      >
         <FolderCard
           show-operation-btns
           v-model="sysStore.systemSettings.container[n - 1]"
@@ -44,7 +47,7 @@ function openFolderEditor() {
       <AddContentsCard
         :label="$t('home.saveWorld.addFolder')"
         min-height="4rem"
-        :card-style="{'min-width': '100%', 'border-radius': '5px'}"
+        :card-style="{ 'min-width': '100%', 'border-radius': '5px' }"
         @click="openFolderEditor"
       />
     </div>

--- a/src/pages/SystemSettings/GeneralPage.vue
+++ b/src/pages/SystemSettings/GeneralPage.vue
@@ -4,6 +4,7 @@ import { useQuasar } from 'quasar';
 import { colorThemes, ColorTheme, Locale } from 'app/src-electron/schema/system';
 import { useSystemStore } from 'src/stores/SystemStore';
 import { assets } from 'src/assets/assets';
+import { setColor } from 'src/color';
 import SsSelect from 'src/components/util/base/ssSelect.vue';
 import ColorThemeBtn from 'src/components/SystemSettings/General/ColorThemeBtn.vue';
 import PlayerCard from 'src/components/SystemSettings/General/PlayerCard.vue';
@@ -71,6 +72,16 @@ function showOwnerDialog() {
         />
       </template>
     </div>
+    <q-toggle
+      v-model="sysStore.systemSettings.user.visionSupport"
+      @update:model-value="val => setColor($q.dark.isActive, val)"
+      :label="
+        sysStore.systemSettings.user.visionSupport
+          ? $t('systemsetting.general.useVisionSupport')
+          : $t('systemsetting.general.noVisionSupport')"
+      class="q-pt-lg"
+      style="font-size: 1rem;"
+    />
 
     <h1>{{ $t("systemsetting.general.autoShutdown") }}</h1>
     <q-checkbox

--- a/src/pages/SystemSettings/RemotePage.vue
+++ b/src/pages/SystemSettings/RemotePage.vue
@@ -22,7 +22,7 @@ function addRemote() {
     <p class="q-my-sm text-body2" style="opacity: .6;">
       {{ $t('shareWorld.descriptRemote') }}
     </p>
-    <p v-if="!consoleStore.isAllWorldStop()" class="q-my-sm text-body2 text-red">
+    <p v-if="!consoleStore.isAllWorldStop()" class="q-my-sm text-body2 text-negative">
       {{ $t('shareWorld.cannotEdit') }}
     </p>
 
@@ -38,9 +38,9 @@ function addRemote() {
             style="min-width: calc(13rem + 24px * 2);"
           />
         </div>
-        <div v-for="n in sysStore.systemSettings.remote.length" :key="sysStore.systemSettings.remote[n-1].pat">
+        <div v-for="n in sysStore.systemSettings.remote.length" :key="sysStore.systemSettings.remote[n - 1].pat">
           <GithubCard
-            v-model="sysStore.systemSettings.remote[n-1]"
+            v-model="sysStore.systemSettings.remote[n - 1]"
             show-unlink
             :disable="!consoleStore.isAllWorldStop()"
           />

--- a/src/pages/WorldTabs/PropertyPage.vue
+++ b/src/pages/WorldTabs/PropertyPage.vue
@@ -17,7 +17,13 @@ const mainStore = useMainStore()
 const propertyStore = usePropertyStore()
 
 // システムが規定するデフォルトプロパティ
-const initProperty: ServerProperties = fromEntries(toEntries(sysStore.staticResouces.properties).map(keyVal =>[keyVal[0], keyVal[1].default]))
+const initProperty: ServerProperties = fromEntries(
+  toEntries(
+    sysStore.staticResouces.properties
+  ).map(
+    keyVal => [keyVal[0], keyVal[1].default]
+  )
+)
 
 // 入力領域のスクロールバーの制御
 const scrollAreaRef = ref()
@@ -36,7 +42,7 @@ function resetAll() {
 /**
  * 画面を一番上に遷移
  */
- function scrollTop() {
+function scrollTop() {
   scrollAreaRef.value.setScrollPosition('vertical', 0)
 }
 </script>
@@ -45,13 +51,18 @@ function resetAll() {
   <div class="mainField">
     <div v-if="isValid(mainStore.world.properties)" class="column fit">
       <div class="row q-py-md">
-        <SsInput dense v-model="propertyStore.searchName" :placeholder="$t('property.main.search')" class="col" />
+        <SsInput
+          dense
+          v-model="propertyStore.searchName"
+          :placeholder="$t('property.main.search')"
+          class="col"
+        />
 
         <SsBtn
           dense
           :label="$t('property.main.resetAll')"
           icon="do_not_disturb_on_total_silence"
-          color="red"
+          color="negative"
           width="6rem"
           @click="resetAll"
           class="q-ml-md"


### PR DESCRIPTION
# 色関連の実装修正

- 色覚サポートに対応
- 色設定を独立させ、それぞれのテーマに応じた色を設定できるように修正
- 色名称を`text-red`から`text-negative`に変更