### PR TITLE
バージョン一覧の描画を更新

### DIFF
--- a/src/components/World/HOME/Top/VersionSelecter/VanillaView.vue
+++ b/src/components/World/HOME/Top/VersionSelecter/VanillaView.vue
@@ -10,11 +10,12 @@ const sysStore = useSystemStore()
 const mainStore = useMainStore()
 const consoleStore = useConsoleStore()
 
-const isRelease = ref(false)
+const isRelease = ref(true)
 const vanillas = sysStore.serverVersions.get('vanilla') as AllVanillaVersion | undefined
 const vanillaOps = vanillas?.map(
   ver => { return { id: ver.id, type: 'vanilla' as const, release: ver.release }}
 )
+const latestID = vanillaOps?.find(ops => ops.release)?.id
 
 // vanillaでないときには最新のバージョンを割り当てる
 if (mainStore.world.version.type !== 'vanilla' && vanillaOps !== void 0) {
@@ -26,9 +27,18 @@ if (mainStore.world.version.type !== 'vanilla' && vanillaOps !== void 0) {
   <div class="row justify-between q-gutter-md items-center">
     <SsSelect
       v-model="mainStore.world.version"
-      :options="vanillaOps?.filter(ver => !isRelease || ver['release'])"
+      :options="vanillaOps?.filter(
+        (ver, idx) => !isRelease || idx == 0 || ver['release']
+      ).map(
+        (ver, idx) => { return {
+          data: ver,
+          label: idx === 0 ? `${ver.id} 【${$t('home.version.latestSnapshot')}】` : ver.id === latestID ? `${ver.id} 【${$t('home.version.latestRelease')}】` : ver.id
+        }}
+      )
+      "
       :label="$t('home.version.versionType')"
-      option-label="id"
+      option-label="label"
+      option-value="data"
       :disable="vanillas === void 0 || consoleStore.status(mainStore.world.id) !== 'Stop'"
       class="col"
       style="min-width: 8rem;"

--- a/src/i18n/en-US/home.ts
+++ b/src/i18n/en-US/home.ts
@@ -1,4 +1,3 @@
-import { title } from "process";
 import { MessageSchema } from "src/boot/i18n";
 
 export const enUSHome: MessageSchema["home"] = {
@@ -16,8 +15,9 @@ export const enUSHome: MessageSchema["home"] = {
     notChange: '(No change required)',
     recommend: 'Recommended',
     installer: 'Installer',
-    loader: 'Loader'
-
+    loader: 'Loader',
+    latestSnapshot: 'Latest snapshot',
+    latestRelease: 'Latest release'
   },
   serverType: {
     vanilla: 'Vanilla (Official)',

--- a/src/i18n/ja/home.ts
+++ b/src/i18n/ja/home.ts
@@ -16,7 +16,9 @@ export const jaHome = {
     notChange: '(変更不要)',
     recommend: '推奨',
     installer: 'インストーラー',
-    loader: 'ローダー'
+    loader: 'ローダー',
+    latestSnapshot: '最新のスナップショット',
+    latestRelease: '最新のリリース'
   },
   serverType: {
     vanilla: 'バニラ (公式)',


### PR DESCRIPTION
# バージョン一覧の描画を更新

- 各種サーバーの種類の説明をより分かりやすく
- 最新のスナップショットとリリースには、それぞれ説明文を付与
- 標準表示を「リリースのみ」に変更
- 「リリースのみ」のトグルの横幅を固定
- 「（推奨）」バージョンを選択すると描画がずれる問題の修正