### PR TITLE
サーバープロパティのUIを更新

### DIFF
--- a/src-electron/core/world/files/properties.ts
+++ b/src-electron/core/world/files/properties.ts
@@ -78,6 +78,8 @@ export const annotations: ServerPropertiesAnnotation = {
     enum: ['default', 'flat', 'largeBiomes', 'amplified', 'buffet'],
   },
 
+  'log-ips': { type: 'boolean', default: true },
+
   // legacy?
   'max-build-height': { type: 'number', default: 256, step: 8 },
 

--- a/src/components/World/Property/SettingBlockView.vue
+++ b/src/components/World/Property/SettingBlockView.vue
@@ -44,7 +44,7 @@ function cancelSettings() {
         @click="cancelSettings"
       >
         <q-tooltip>
-          <p class="text-caption q-ma-none" v-html="$t('property.resetProperty', { defaultProperty: defaultProperty })" />
+          <p class="text-caption q-ma-none" v-html="$t('property.resetProperty', { defaultProperty: defaultProperty !== '' ? defaultProperty : $t('property.empty') })" />
         </q-tooltip>
       </q-btn>
     </q-item-section>

--- a/src/i18n/en-US/property.ts
+++ b/src/i18n/en-US/property.ts
@@ -103,6 +103,7 @@ export const enUSproperty: MessageSchema['property'] = {
   resetProperty: '\
     Reset setting to default setting \"{defaultProperty}\"<br>\
     You can change basic settings from "System Settings" > "Properties".',
+  empty: '(Empty)',
   failed: 'Failed to load properties',
   reset: 'Reset property settings',
   result: 'Result',

--- a/src/i18n/ja/property.ts
+++ b/src/i18n/ja/property.ts
@@ -99,6 +99,7 @@ export const jaProperty = {
   resetProperty: '\
     基本設定の{defaultProperty}に設定を戻します<br>\
     「システム設定」>「プロパティ」 より基本設定を変更できます',
+  empty: '(空欄)',
   failed: 'プロパティが読み込めませんでした',
   reset: 'プロパティ設定をリセット',
   result: '検索結果',

--- a/src/i18n/utils/tFunc.ts
+++ b/src/i18n/utils/tFunc.ts
@@ -30,6 +30,7 @@ export function setI18nFunc(t: tFunc) {
   _t = t
 }
 
+export function $T(key: string): string;
 export function $T(key: FullKeys<MessageSchema>): string;
 export function $T(key: FullKeys<MessageSchema>, args: Record<string, unknown>): string;
 export function $T(key: FullKeys<MessageSchema>, defaultMessage: string): string;
@@ -37,7 +38,7 @@ export function $T(key: FullKeys<MessageSchema>, defaultMessage: string): string
  * 翻訳で利用する変数部分にさらに翻訳が必要な値がわたってきた際に、
  * 翻訳済みの値を変数部分に再格納するためのラッパー
  */
-export function $T(key: FullKeys<MessageSchema>, args?: Record<string, unknown> | string) {
+export function $T(key: FullKeys<MessageSchema> | string, args?: Record<string, unknown> | string) {
   if (args === void 0) {
     return _t(key)
   }
@@ -62,6 +63,7 @@ export function $T(key: FullKeys<MessageSchema>, args?: Record<string, unknown> 
     )
   }
 }
+
 
 /**
  * プログレスの翻訳に当てるためのラッパー関数

--- a/src/pages/SystemSettings/PropertyPage.vue
+++ b/src/pages/SystemSettings/PropertyPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import { thumbStyle } from 'src/components/World/scrollBar';
 import { useSystemStore } from 'src/stores/SystemStore';
 import { usePropertyStore } from 'src/stores/WorldTabs/PropertyStore'
@@ -8,6 +9,16 @@ import SettingsView from 'src/components/World/Property/SettingsView.vue';
 
 const sysStore = useSystemStore()
 const propertyStore = usePropertyStore()
+
+// 入力領域のスクロールバーの制御
+const scrollAreaRef = ref()
+
+/**
+ * 画面を一番上に遷移
+ */
+function scrollTop() {
+  scrollAreaRef.value.setScrollPosition('vertical', 0)
+}
 </script>
 
 <template>
@@ -20,12 +31,12 @@ const propertyStore = usePropertyStore()
         class="q-pb-md" />
 
       <div class="row fit" style="flex: 1 1 0;">
-        <SideMenuView />
+        <SideMenuView @scroll-top="scrollTop" />
 
         <q-separator vertical inset />
 
         <div class="col">
-          <q-scroll-area :thumb-style="thumbStyle" class="fit">
+          <q-scroll-area ref="scrollAreaRef" :thumb-style="thumbStyle" class="fit">
             <SettingsView v-model="sysStore.systemSettings.world.properties" />
           </q-scroll-area>
         </div>

--- a/src/stores/WorldTabs/PropertyStore.ts
+++ b/src/stores/WorldTabs/PropertyStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { ServerProperties } from 'app/src-electron/schema/serverproperty';
 import { pGroupKey, propertyClasses } from 'src/components/World/Property/classifications';
 import { keys, values } from 'src/scripts/obj';
+import { $T } from 'src/i18n/utils/tFunc';
 
 const disableProperties = ['level-name']
 
@@ -19,9 +20,15 @@ export const usePropertyStore = defineStore('propertyStore', {
     searchProperties(targetProps: ServerProperties) {
       // 検索欄に文字が入った場合は該当するプロパティ全てを返す
       if (this.searchName !== '') {
-        return keys(targetProps).filter(
+        // タイトルの検索
+        const searchTitles = keys(targetProps).filter(
           prop => prop.match(this.searchName)
         )
+        // 説明文の検索
+        const searchDescs = keys(targetProps).filter(
+          prop => $T(`property.description['${prop}']`).match(this.searchName)
+        )
+        return searchTitles.concat(searchDescs)
       }
       // グループごとのプロパティを返す
       else {


### PR DESCRIPTION
# サーバープロパティのUI動作改善

#40 に基づく更新

- [x] 検索欄に説明文の文言を入力しても検索にヒットするように改良
- [x] `log-ips`のデフォルト設定&説明文を追加（ただし、#42 に関連するバックエンドの問題あり）
- [x] 初期設定の存在しないプロパティのリセット時の説明文が「基本設定のに設定します」という不自然な表記になっている問題の修正