### PR TITLE
最終更新時刻に関連するUIの修正

### DIFF
--- a/src-electron/core/world/cusomMap.ts
+++ b/src-electron/core/world/cusomMap.ts
@@ -138,7 +138,7 @@ export async function loadCustomMap(
 }
 
 function longToNumber(value: any): number {
-  return (value[0] << 32) + value[1];
+  return Number(value);
 }
 
 /**

--- a/src-electron/core/world/world.ts
+++ b/src-electron/core/world/world.ts
@@ -121,7 +121,7 @@ export async function newWorld(): Promise<WithError<Failable<World>>> {
     version: { type: 'vanilla', ...latestRelease },
     using: false,
     remote: undefined,
-    last_date: getCurrentTimestamp(),
+    last_date: getCurrentTimestamp(true),
     last_user: undefined,
     memory: systemSettings.world.memory,
     javaArguments: systemSettings.world.javaArguments,

--- a/src/components/MainLayout/WorldList.vue
+++ b/src/components/MainLayout/WorldList.vue
@@ -13,6 +13,12 @@ import WorldTab from './WorldTab.vue';
 import SearchWorldView from '../World/SearchWorldView.vue';
 import IconButtonView from '../World/utils/IconButtonView.vue';
 
+interface Prop {
+  minWidth: number
+  maxWidth: number
+}
+defineProps<Prop>()
+
 const router = useRouter()
 const sysStore = useSystemStore()
 const mainStore = useMainStore();
@@ -59,7 +65,7 @@ async function createNewWorld() {
     style="height: 100vh;"
   >
     <div class="q-mini-drawer-only">
-      <q-item clickable @click="sysStore.systemSettings.user.drawerWidth = 300">
+      <q-item clickable @click="sysStore.systemSettings.user.drawerWidth = maxWidth">
         <q-avatar size="2rem">
           <q-icon
             size="2rem"
@@ -75,7 +81,7 @@ async function createNewWorld() {
       :icon-src="assets.svg.menuicon_open(getCssVar('primary')?.replace('#', '%23'))"
       :label="$t('worldList.allWorld')"
       :tooltip="$t('worldList.minimizeList')"
-      @click="sysStore.systemSettings.user.drawerWidth = 100"
+      @click="sysStore.systemSettings.user.drawerWidth = minWidth"
       class="q-mini-drawer-hide"
     />
 

--- a/src/components/MainLayout/WorldTab.vue
+++ b/src/components/MainLayout/WorldTab.vue
@@ -64,7 +64,7 @@ function selectWorldIdx() {
       @mouseover="runBtnHovered = true"
       @mouseleave="runBtnHovered = false"
     >
-      <q-avatar square size="4rem">
+      <q-avatar square size="4.5rem">
         <q-img
           :src="world.avater_path ?? assets.png.unset"
           :ratio="1"
@@ -89,16 +89,17 @@ function selectWorldIdx() {
       </q-avatar>
     </q-item-section>
     <q-item-section>
-      <div>
-        <p class="worldName">{{ world.name }}</p>
-        <p class="versionName">
-          {{
-            world.version.type === 'vanilla' 
-              ? world.version.id  
-              :`${world.version.id} (${$t(`home.serverType.${world.version.type}`)})` 
-          }}
-        </p>
-      </div>
+      <q-item-label class="worldName">{{ world.name }}</q-item-label>
+      <q-item-label class="versionName">
+        {{
+          world.version.type === 'vanilla' 
+            ? world.version.id  
+            :`${world.version.id} (${$t(`home.serverType.${world.version.type}`)})` 
+        }}
+      </q-item-label>
+      <q-item-label v-if="world.last_date" class="date">
+        {{ $t('worldList.lastPlayed', { datetime: $d(world.last_date, 'dateTime') } ) }}
+      </q-item-label>
     </q-item-section>
     <q-tooltip
       v-if="sysStore.systemSettings.user.drawerWidth < 200"
@@ -114,7 +115,7 @@ function selectWorldIdx() {
 
 <style scoped lang="scss">
 .worldBlock {
-  height: 5.5rem;
+  height: 6.5rem;
 }
 
 .worldName {
@@ -126,6 +127,11 @@ function selectWorldIdx() {
 .versionName {
   font-size: 1rem;
   margin-bottom: 4px;
+}
+
+.date {
+  font-size: .75rem;
+  opacity: .6;
 }
 
 .badge {

--- a/src/components/World/HOME/CustomMap/CustomMapImporter/CustomMapImporterView.vue
+++ b/src/components/World/HOME/CustomMap/CustomMapImporter/CustomMapImporterView.vue
@@ -131,8 +131,9 @@ onMounted(async () => {
               :icon="localWorld.icon ?? assets.png.unset"
               :world-name="localWorld.levelName"
               :version-name="localWorld.versionName"
+              :last-played="localWorld.lastPlayed"
               @click="showCheckDialog(localWorld)"
-              style="min-width: 20rem; max-width: 20rem;;"
+              style="min-width: 20rem; max-width: 20rem;"
             />
           </template>
         </div>

--- a/src/components/World/HOME/CustomMap/CustomMapImporter/checkDialog.vue
+++ b/src/components/World/HOME/CustomMap/CustomMapImporter/checkDialog.vue
@@ -34,6 +34,7 @@ async function updateWorld() {
         :icon="customMap.icon ?? assets.png.unset"
         :world-name="customMap.levelName"
         :version-name="customMap.versionName"
+        :last-played="customMap.lastPlayed"
       />
     </BaseDialogCard>
   </q-dialog>

--- a/src/components/World/ShareWorld/selecters/github/ExistedGitHubDialog.vue
+++ b/src/components/World/ShareWorld/selecters/github/ExistedGitHubDialog.vue
@@ -53,6 +53,7 @@ async function setRemote() {
         :icon="rIcon"
         :world-name="rWorldName"
         :version-name="rVersionName"
+        :last-played="rLastPlayed"
         style="min-width: 20rem; max-width: 20rem;;"
       />
     </BaseDialogCard>

--- a/src/components/World/ShareWorld/selecters/github/GitHubSelecterDialog.vue
+++ b/src/components/World/ShareWorld/selecters/github/GitHubSelecterDialog.vue
@@ -31,7 +31,8 @@ function checkSetExistedRemote(selectedRemote: RemoteWorld) {
       remoteData: prop.remoteData,
       rWorldName: selectedRemote.remote.name,
       rIcon: selectedRemote.avater_path,
-      rVersionName: selectedRemote.version.id
+      rVersionName: selectedRemote.version.id,
+      rLastPlayed: selectedRemote.last_date
     } as GithubCheckDialogProp
   }).onOk(() => {
     mainStore.world.version = selectedRemote.version
@@ -48,7 +49,8 @@ function checkSetNewRemote() {
       remoteData: prop.remoteData,
       rWorldName: mainStore.world.name,
       rIcon: mainStore.world.avater_path,
-      rVersionName: mainStore.world.version.id
+      rVersionName: mainStore.world.version.id,
+      rLastPlayed: mainStore.world.last_date
     } as GithubCheckDialogProp
   }).onOk(onDialogOK)
 }
@@ -119,6 +121,7 @@ onMounted(async () => {
               :icon="remoteWorld.avater_path"
               :world-name="remoteWorld.remote.name"
               :version-name="remoteWorld.version.id"
+              :last-played="remoteWorld.last_date"
               @click="checkSetExistedRemote(remoteWorld)"
               style="min-width: 20rem; max-width: 20rem;;"
             />

--- a/src/components/World/ShareWorld/selecters/iRemoteSelecter.ts
+++ b/src/components/World/ShareWorld/selecters/iRemoteSelecter.ts
@@ -15,6 +15,7 @@ export interface GithubCheckDialogProp {
   rIcon?: ImageURI
   rVersionName: string
   rWorldName: string
+  rLastPlayed: number
 }
 
 export async function setRemoteWorld(rWorld: Remote, isExist: boolean) {

--- a/src/components/util/WorldItem.vue
+++ b/src/components/util/WorldItem.vue
@@ -5,6 +5,7 @@ interface Prop {
   icon?: ImageURI,
   worldName: string,
   versionName: string,
+  lastPlayed?: number,
   onClick?: () => void
 }
 defineProps<Prop>()
@@ -24,6 +25,9 @@ defineProps<Prop>()
     <q-item-section>
       <q-item-label class="name text-omit">{{ worldName.replace(/§./g, "").trim() }}</q-item-label>
       <q-item-label class="version">{{ versionName }}</q-item-label>
+      <q-item-label v-if="lastPlayed" class="date">
+        {{ $t('worldList.lastPlayed', { datetime: $d(lastPlayed, 'dateTime') } ) }}
+      </q-item-label>
     </q-item-section>
   </q-item>
 </template>
@@ -39,6 +43,11 @@ defineProps<Prop>()
 
 .version {
   font-size: 1rem;
+  opacity: .6;
+}
+
+.date {
+  font-size: .75rem;
   opacity: .6;
 }
 </style>

--- a/src/i18n/en-US/worldList.ts
+++ b/src/i18n/en-US/worldList.ts
@@ -9,6 +9,7 @@ export const enUSWorldList:MessageSchema['worldList'] = {
     addCustomWorld: 'Add Custom world',
     selectZip: 'Select ZIP file',
     selectFolder: 'Select folder',
+    lastPlayed: "({datetime})",
     addSingleWorld: 'Add single world',
     loadSingleWorld: 'Loading<br>single play world',
     noSingleWorld: 'Single play world<br>was not found',

--- a/src/i18n/ja/worldList.ts
+++ b/src/i18n/ja/worldList.ts
@@ -7,6 +7,7 @@ export const jaWorldList = {
     addCustomWorld: '配布ワールドを導入',
     selectZip: 'ZIPファイルを選択',
     selectFolder: 'フォルダを選択',
+    lastPlayed: '({datetime})',
     addSingleWorld: 'シングルワールドを導入',
     loadSingleWorld: 'シングルプレイワールドを<br>読み込み中',
     noSingleWorld: 'シングルプレイワールドは<br>見つかりませんでした',

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -4,19 +4,21 @@ import WorldList from 'src/components/MainLayout/WorldList.vue';
 import WorldPage from 'src/pages/WorldPage.vue';
 
 const sysStore = useSystemStore()
+const minLeftWidth = 115
+const maxLeftWidth = 400
 </script>
 
 <template>
   <q-layout view="hHh Lpr rff">
     <q-splitter
       v-model="sysStore.systemSettings.user.drawerWidth"
-      :limits="[100, 400]"
+      :limits="[minLeftWidth, maxLeftWidth]"
       unit="px"
       emit-immediately
       style="height: 100vh; width: 100vw;"
     >
       <template #before>
-        <WorldList />
+        <WorldList :min-width="minLeftWidth" :max-width="maxLeftWidth" />
       </template>
       <template #after>
         <WorldPage />

--- a/src/pages/SystemSettings/InfoPage.vue
+++ b/src/pages/SystemSettings/InfoPage.vue
@@ -38,7 +38,7 @@ function openMIT() {
       </div>
       
       <!-- 最終更新日 -->
-      <div v-if="lastUpdateDateTime" class="text-caption q-pt-sm" tyle="opacity: .6;">
+      <div v-if="lastUpdateDateTime" class="text-caption q-pt-sm" style="opacity: .6;">
         {{ $t('systemsetting.info.finalUpdate', { datetime: $d(lastUpdateDateTime, 'dateTime') } ) }}
       </div>
     </div>


### PR DESCRIPTION
# 最終更新時刻関連の修正

基本的には #34 に関連する修正

具体的な修正点を下記に示す

- シングルワールドの最終プレイ日時を表示
- 既存ワールドの最終プレイ日時を表示
- 既存ワールドの余白を調整
- １分以内に新規ワールドを複数作成した場合に，最も新しく作成されるワールドが一番上に表示されない問題の修正
- システム設定の「システム情報」において「最終更新日」が通常表示となっていたため，表示色を暗くする修正