### PR TITLE
🐛 mkdir呼び出しにawaitを追加し、同期メソッドのmkdirSyncを作成

### DIFF
--- a/src-electron/util/path.ts
+++ b/src-electron/util/path.ts
@@ -85,7 +85,7 @@ export class Path {
   }
 
   async rename(newpath: Path) {
-    newpath.parent().mkdir(true);
+    await newpath.parent().mkdir(true);
     await fs.rename(this.path, newpath.absolute().str());
   }
 
@@ -93,28 +93,33 @@ export class Path {
     if (!this.exists()) await fs.mkdir(this.path, { recursive });
   }
 
+  /** 同期ディレクトリ生成(非推奨) */
+  mkdirSync(recursive = false) {
+    if (!this.exists()) fs.mkdirSync(this.path, { recursive });
+  }
+
   async mklink(target: Path) {
     await new Promise((resolve) => fs.link(target.path, this.path, resolve));
   }
 
   async write(content: BytesData) {
-    this.parent().mkdir(true);
+    await this.parent().mkdir(true);
     await content.write(this.path);
   }
 
   async writeText(content: string) {
-    this.parent().mkdir(true);
+    await this.parent().mkdir(true);
     await fs.writeFile(this.path, content);
   }
 
   /** 同期書き込み(非推奨) */
   writeTextSync(content: string) {
-    this.parent().mkdir(true);
+    this.parent().mkdirSync(true);
     fs.writeFileSync(this.path, content);
   }
 
   async writeJson<T>(content: T) {
-    this.parent().mkdir(true);
+    await this.parent().mkdir(true);
     await fs.writeFile(this.path, JSON.stringify(content));
   }
 
@@ -170,7 +175,7 @@ export class Path {
     // fs.moveだとうまくいかないことがあったので再帰的にファイルを移動
     async function recursiveMove(path: Path, target: Path) {
       if (await path.isDirectory()) {
-        target.mkdir(true);
+        await target.mkdir(true);
         await asyncForEach(await path.iter(), async (child) => {
           await recursiveMove(child, target.child(child.basename()));
         });


### PR DESCRIPTION
# 親ディレクトリ生成の処理を修正

以下2点の問題を修正
- ファイルの同期書き込み時に非同期のディレクトリ生成を実行していた
- ファイル操作に伴う親ディレクトリ生成の非同期処理を待機していなかった

この修正に伴い #46 は修正されました