### PR TITLE
ZIP形式のMODに対応

### DIFF
--- a/src-electron/core/world/dialog.ts
+++ b/src-electron/core/world/dialog.ts
@@ -47,13 +47,13 @@ export function pickDialog(windowGetter: () => BrowserWindow | undefined) {
   async function result(
     options: {
       type:
-        | 'datapack'
-        | 'world'
-        | 'plugin'
-        | 'mod'
-        | 'image'
-        | 'container'
-        | 'backup';
+      | 'datapack'
+      | 'world'
+      | 'plugin'
+      | 'mod'
+      | 'image'
+      | 'container'
+      | 'backup';
       isFile?: boolean;
       container?: WorldContainer;
     } & DialogOptions
@@ -88,8 +88,8 @@ export function pickDialog(windowGetter: () => BrowserWindow | undefined) {
       case 'mod':
       case 'plugin':
         filters.push({
-          extensions: ['jar'],
-          name: 'jar',
+          extensions: ['jar', 'zip'],
+          name: 'jar/zip',
         });
         break;
       case 'datapack':

--- a/src-electron/core/world/files/addtional/mod.ts
+++ b/src-electron/core/world/files/addtional/mod.ts
@@ -6,7 +6,7 @@ import { errorMessage } from 'app/src-electron/util/error/construct';
 import { MOD_CACHE_PATH } from 'app/src-electron/core/const';
 
 async function loader(path: Path): Promise<Failable<ModData>> {
-  if (path.extname() !== '.jar')
+  if (path.extname() !== '.jar' && path.extname() !== '.zip')
     return errorMessage.data.path.invalidContent.invalidMod({
       path: path.path,
       type: 'file',


### PR DESCRIPTION
modの管理画面からzip形式のmodを管理できるように。

modの中身の正常性検証はjar/zipともに行っていない。

※この対応で十分か要相談なのでDraftとして発行する