### PR TITLE
サーバープロパティの検索アルゴリズムを修正

### DIFF
--- a/src/scripts/objFillter.ts
+++ b/src/scripts/objFillter.ts
@@ -48,3 +48,7 @@ export function uniqueArrayDict<T extends Record<string, any>>(dicts: T[], key: 
 
   return uniqueArray
 }
+
+export function uniqueArray<T>(array: T[]) {
+  return [...new Set(array)]
+}

--- a/src/stores/WorldTabs/PropertyStore.ts
+++ b/src/stores/WorldTabs/PropertyStore.ts
@@ -3,6 +3,7 @@ import { ServerProperties } from 'app/src-electron/schema/serverproperty';
 import { pGroupKey, propertyClasses } from 'src/components/World/Property/classifications';
 import { keys, values } from 'src/scripts/obj';
 import { $T } from 'src/i18n/utils/tFunc';
+import { uniqueArray } from 'src/scripts/objFillter';
 
 const disableProperties = ['level-name']
 
@@ -18,28 +19,32 @@ export const usePropertyStore = defineStore('propertyStore', {
      * プロパティの検索
      */
     searchProperties(targetProps: ServerProperties) {
-      // 検索欄に文字が入った場合は該当するプロパティ全てを返す
-      if (this.searchName !== '') {
-        // タイトルの検索
-        const searchTitles = keys(targetProps).filter(
-          prop => prop.match(this.searchName)
-        )
-        // 説明文の検索
-        const searchDescs = keys(targetProps).filter(
-          prop => $T(`property.description['${prop}']`).match(this.searchName)
-        )
-        return searchTitles.concat(searchDescs)
-      }
-      // グループごとのプロパティを返す
-      else {
-        if (this.selectTab === 'other') {
-          const classifiedKeies = values(propertyClasses).flat()
-          return keys(targetProps).filter(k => !classifiedKeies.includes(k) && !disableProperties.includes(k))
+      function getPropertyList(searchName: string, selectTab: pGroupKey) {
+        // 検索欄に文字が入った場合は該当するプロパティ全てを返す
+        if (searchName !== '') {
+          // タイトルの検索
+          const searchTitles = keys(targetProps).filter(
+            prop => prop.match(searchName)
+          )
+          // 説明文の検索
+          const searchDescs = keys(targetProps).filter(
+            prop => $T(`property.description['${prop}']`).match(searchName)
+          )
+          return searchTitles.concat(searchDescs)
         }
+        // グループごとのプロパティを返す
         else {
-          return propertyClasses[this.selectTab]
+          if (selectTab === 'other') {
+            const classifiedKeies = values(propertyClasses).flat()
+            return keys(targetProps).filter(k => !classifiedKeies.includes(k) && !disableProperties.includes(k))
+          }
+          else {
+            return propertyClasses[selectTab]
+          }
         }
       }
+
+      return uniqueArray(getPropertyList(this.searchName, this.selectTab))
     },
     /**
      * 引数で指定したグループが選択（フォーカス）されているか否か


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# サーバープロパティの重複表示を解消

英語版において，サーバープロパティを検索した際に，同一の項目が複数表示される問題を修正
Close #69 