### PR TITLE
latest.logの内容を取得する機能を追加

### DIFF
--- a/src-electron/api/api.ts
+++ b/src-electron/api/api.ts
@@ -146,6 +146,9 @@ export interface API extends IAPI {
       backup: BackupData
     ) => Promise<WithError<Failable<World>>>;
 
+    /** ワールドの最新のログを取得する */
+    FetchLatestWorldLog: (world: WorldEdited) => Promise<Failable<string[]>>;
+
     /**
      * プレイヤーを名前またはUUIDで取得/検索する(完全一致のみ)
      * 検索したことのあるデータの取得は高速

--- a/src-electron/api/api.ts
+++ b/src-electron/api/api.ts
@@ -147,7 +147,7 @@ export interface API extends IAPI {
     ) => Promise<WithError<Failable<World>>>;
 
     /** ワールドの最新のログを取得する */
-    FetchLatestWorldLog: (world: WorldEdited) => Promise<Failable<string[]>>;
+    FetchLatestWorldLog: (world: WorldID) => Promise<Failable<string[]>>;
 
     /**
      * プレイヤーを名前またはUUIDで取得/検索する(完全一致のみ)
@@ -163,8 +163,8 @@ export interface API extends IAPI {
     GetCacheContents: ((
       type: 'datapack'
     ) => Promise<WithError<CacheFileData<DatapackData>[]>>) &
-      ((type: 'plugin') => Promise<WithError<CacheFileData<PluginData>[]>>) &
-      ((type: 'mod') => Promise<WithError<CacheFileData<ModData>[]>>);
+    ((type: 'plugin') => Promise<WithError<CacheFileData<PluginData>[]>>) &
+    ((type: 'mod') => Promise<WithError<CacheFileData<ModData>[]>>);
 
     /** Version一覧を取得 useCache===trueのときローカルのキャッシュを使用する(高速) */
     GetVersions: (
@@ -213,26 +213,26 @@ export interface API extends IAPI {
         isFile: boolean;
       } & DialogOptions
     ) => Promise<Failable<CustomMapData>>) &
-      ((
-        options: { type: 'datapack'; isFile: boolean } & DialogOptions
-      ) => Promise<Failable<NewFileData<DatapackData>>>) &
-      ((
-        options: {
-          type: 'plugin';
-        } & DialogOptions
-      ) => Promise<Failable<NewFileData<PluginData>>>) &
-      ((
-        options: { type: 'mod' } & DialogOptions
-      ) => Promise<Failable<NewFileData<ModData>>>) &
-      ((
-        options: { type: 'image' } & DialogOptions
-      ) => Promise<Failable<ImageURIData>>) &
-      ((
-        options: { type: 'container' } & DialogOptions
-      ) => Promise<Failable<WorldContainer>>) &
-      ((
-        options: { type: 'backup'; container: WorldContainer } & DialogOptions
-      ) => Promise<Failable<BackupData>>);
+    ((
+      options: { type: 'datapack'; isFile: boolean } & DialogOptions
+    ) => Promise<Failable<NewFileData<DatapackData>>>) &
+    ((
+      options: {
+        type: 'plugin';
+      } & DialogOptions
+    ) => Promise<Failable<NewFileData<PluginData>>>) &
+    ((
+      options: { type: 'mod' } & DialogOptions
+    ) => Promise<Failable<NewFileData<ModData>>>) &
+    ((
+      options: { type: 'image' } & DialogOptions
+    ) => Promise<Failable<ImageURIData>>) &
+    ((
+      options: { type: 'container' } & DialogOptions
+    ) => Promise<Failable<WorldContainer>>) &
+    ((
+      options: { type: 'backup'; container: WorldContainer } & DialogOptions
+    ) => Promise<Failable<BackupData>>);
   };
 }
 

--- a/src-electron/core/misc/tempPath.ts
+++ b/src-electron/core/misc/tempPath.ts
@@ -2,6 +2,7 @@ import { genUUID } from 'app/src-electron/tools/uuid';
 import { tempPath } from '../const';
 import { onQuit } from 'app/src-electron/lifecycle/lifecycle';
 
+/** 一時的なディレクトリを確保 */
 export async function allocateTempDir() {
   const dir = tempPath.child(genUUID());
   await dir.mkdir(true);

--- a/src-electron/core/server/server.ts
+++ b/src-electron/core/server/server.ts
@@ -9,6 +9,7 @@ import { decoratePromise } from 'app/src-electron/util/promiseDecorator';
 import { isError } from 'app/src-electron/util/error/error';
 import { GroupProgressor } from '../progress/progress';
 import { trimAnsi } from 'app/src-electron/util/ansi';
+import { WorldLogHandler } from '../world/loghandler';
 
 export type RunServer = Promise<Failable<undefined>> & {
   runCommand: (command: string) => Promise<void>;
@@ -28,10 +29,18 @@ export function runServer(
 
     const { javaArgs, javaPath } = readyResult;
 
+    // latest.logをアーカイブ化する
+    const loghandler = new WorldLogHandler(cwdPath)
+    await loghandler.archive()
+
     const onStart = () => api.send.StartServer(id);
     const onFinish = () => api.send.FinishServer(id);
-    const console = (value: string, isError: boolean) =>
-      api.send.AddConsole(id, trimAnsi(value), isError);
+    const console = (value: string, isError: boolean) => {
+      const trimmed = trimAnsi(value)
+      // コンソールの内容をGUIに表示
+      api.send.AddConsole(id, trimmed, isError);
+      loghandler.append(trimmed)
+    }
 
     // サーバーの実行を待機
     process = serverProcess(
@@ -45,6 +54,10 @@ export function runServer(
     );
     const runresult = await process;
     process = undefined;
+
+    // 一時保管したlogをリセット
+    await loghandler.flash()
+
     return runresult;
   }
 

--- a/src-electron/core/world/handler.ts
+++ b/src-electron/core/world/handler.ts
@@ -36,6 +36,7 @@ import { createTar, decompressTar } from 'app/src-electron/util/tar';
 import { BackupData } from 'app/src-electron/schema/filedata';
 import { allocateTempDir } from '../misc/tempPath';
 import { portInUse } from 'app/src-electron/util/port';
+import { WorldLogHandler } from './loghandler';
 
 /** 複数の処理を並列で受け取って直列で処理 */
 class PromiseSpooler {

--- a/src-electron/core/world/loghandler.ts
+++ b/src-electron/core/world/loghandler.ts
@@ -1,0 +1,82 @@
+import { AwaitOnce } from "app/src-electron/util/awaitOnce";
+import { allocateTempDir } from "../misc/tempPath";
+import { Path } from "app/src-electron/util/path";
+import { gzip } from "app/src-electron/util/gz";
+import { isError } from "app/src-electron/util/error/error";
+import { DateFormatter } from "app/src-electron/util/dateFormatter";
+import { genUUID } from "app/src-electron/tools/uuid";
+import { Failable } from "app/src-electron/schema/error";
+
+// 起動中のログに関する処理
+const dirGetter = new AwaitOnce(allocateTempDir)
+
+export class WorldLogHandler {
+    logsPath: Path
+    tempPath: AwaitOnce<Path>
+
+    constructor(worldPath: Path) {
+        this.logsPath = worldPath.child("logs")
+        this.tempPath = new AwaitOnce(async () => {
+            const dir = await dirGetter.get()
+            return dir.child(genUUID() + ".log")
+        })
+    }
+
+    /** 
+     * 現状のlatest.logをアーカイブ化する(存在する場合)
+     */
+    async archive() {
+        const latestPath = this.LatestLogPath
+        if (!latestPath.exists()) return
+        const gz = await gzip.fromFile(latestPath)
+        if (isError(gz)) return
+
+        const date = await latestPath.lastUpdateTime()
+        await this.getArchivePath(date).write(gz)
+        await latestPath.remove()
+    }
+
+    private get LatestLogPath() {
+        return this.logsPath.child("latest.log")
+    }
+
+    private getArchivePath(date: Date) {
+        const base = new DateFormatter(d => `${d.YYYY}-${d.MM}-${d.DD}`).format(date)
+        let i = 1
+        let path = this.logsPath.child(`${base}-${i}.log.gz`)
+        while (path.exists()) path = this.logsPath.child(`${base}-${++i}.log.gz`)
+        return path
+    }
+
+    /** 一時記録用のログファイルに追記 */
+    async append(content: string) {
+        const tmp = await this.tempPath.get()
+        tmp.appendText(content)
+    }
+
+    /** 
+     * latest.logが存在しない場合は一時記録用のログファイルの内容をlatest.logとし、一時記録用のログファイルをリセット
+     */
+    async flash() {
+        const tmp = await this.tempPath.get()
+        if (!tmp.exists()) return
+
+        const latest = this.LatestLogPath
+
+        if (!latest.exists()) {
+            tmp.moveTo(latest)
+        } else {
+            tmp.remove()
+        }
+    }
+
+    /** latest.logの内容を取得 */
+    async loadLatest(): Promise<Failable<string[]>> {
+        const latest = this.LatestLogPath
+        const content = await latest.readText()
+        if (isError(content)) return content
+        return content.split("\n")
+    }
+}
+
+

--- a/src-electron/core/world/world.ts
+++ b/src-electron/core/world/world.ts
@@ -21,6 +21,7 @@ import { Failable, WithError } from 'app/src-electron/schema/error';
 import { WorldProgressor } from '../progress/progress';
 import { BackupData } from 'app/src-electron/schema/filedata';
 import { getCurrentTimestamp } from 'app/src-electron/util/timestamp';
+import { WorldLogHandler } from './loghandler';
 
 export async function getWorldAbbrs(
   worldContainer: WorldContainer
@@ -241,4 +242,17 @@ export async function reboot(worldID: WorldID): Promise<void> {
   const handler = WorldHandler.get(worldID);
   if (isError(handler)) return;
   await handler.reboot();
+}
+
+/**
+ * ワールドの最新のログを取得する
+ */
+export async function fetchLatestWorldLog(
+  worldID: WorldID
+): Promise<Failable<string[]>> {
+  const handler = WorldHandler.get(worldID);
+
+  if (isError(handler)) return handler;
+
+  return await new WorldLogHandler(handler.getSavePath()).loadLatest()
 }

--- a/src-electron/core/world/world.ts
+++ b/src-electron/core/world/world.ts
@@ -254,5 +254,14 @@ export async function fetchLatestWorldLog(
 
   if (isError(handler)) return handler;
 
-  return await new WorldLogHandler(handler.getSavePath()).loadLatest()
+  const log = await new WorldLogHandler(handler.getSavePath()).loadLatest()
+
+  if (isError(log)) {
+    return errorMessage.core.world.missingLatestLog({
+      name: handler.name,
+      container: handler.container
+    })
+  }
+
+  return log
 }

--- a/src-electron/electron-preload.ts
+++ b/src-electron/electron-preload.ts
@@ -59,9 +59,9 @@ function invoke<C extends string>(
 ): FrontInvoke<C, Func<any[], Promise<any>>> {
   return ((...args: any[]) =>
     ipcRenderer.invoke(channel, ...args)) as FrontInvoke<
-    C,
-    Func<any[], Promise<any>>
-  >;
+      C,
+      Func<any[], Promise<any>>
+    >;
 }
 
 // MainでWindowの処理を非同期で待機
@@ -121,6 +121,8 @@ const api: FrontAPI = {
   invokeRestoreWorld: invoke('RestoreWorld'),
 
   invokeRunWorld: invoke('RunWorld'),
+
+  invokeFetchLatestWorldLog: invoke('FetchLatestWorldLog'),
 
   invokeGetPlayer: invoke('GetPlayer'),
 

--- a/src-electron/ipc/back.ts
+++ b/src-electron/ipc/back.ts
@@ -15,6 +15,7 @@ import {
   duplicateWorld,
   backupWorld,
   restoreWorld,
+  fetchLatestWorldLog,
 } from '../core/world/world';
 import { openBrowser, openFolder } from '../tools/shell';
 import { getSystemSettings, setSystemSettings } from '../core/stores/system';
@@ -59,6 +60,8 @@ export const getBackListener = (
     RestoreWorld: restoreWorld,
 
     RunWorld: runWorld,
+
+    FetchLatestWorldLog:fetchLatestWorldLog,
 
     GetPlayer: getPlayer,
 

--- a/src-electron/util/awaitOnce.ts
+++ b/src-electron/util/awaitOnce.ts
@@ -1,0 +1,19 @@
+
+
+/** 一度だけAsyncでデータを取得し、それ以降は以前取得したデータを使いまわす場合に使う */
+export class AwaitOnce<T>{
+    private value: (() => Promise<T>) | T
+    private fetched = false
+    constructor(fetch: () => Promise<T>) {
+        this.value = fetch
+    }
+
+    async get(): Promise<T> {
+        if (this.fetched) {
+            return this.value as T
+        }
+        this.fetched = true
+        this.value = (this.value as () => Promise<T>)() as T
+        return await this.value
+    }
+}

--- a/src-electron/util/dateFormatter.ts
+++ b/src-electron/util/dateFormatter.ts
@@ -1,0 +1,38 @@
+
+function paddedNumber(n: number, digit: number) {
+    return n.toString().padStart(digit, '0');
+}
+
+export class DateForFormatter {
+    date: Date
+    constructor(date: Date) {
+        this.date = date
+    }
+
+    get YYYY() {
+        return paddedNumber(this.date.getFullYear(), 4)
+    }
+
+    get MM() {
+        return paddedNumber(this.date.getMonth() + 1, 2)
+    }
+
+    get DD() {
+        return paddedNumber(this.date.getDate(), 2)
+    }
+
+    get HH() {
+        return paddedNumber(this.date.getHours(), 2)
+    }
+
+}
+
+export class DateFormatter {
+    formatter: (date: DateForFormatter) => string
+    constructor(formatter: (date: DateForFormatter) => string) {
+        this.formatter = formatter
+    }
+    format(date: Date) {
+        return this.formatter(new DateForFormatter(date))
+    }
+}

--- a/src-electron/util/error/schema/core.ts
+++ b/src-electron/util/error/schema/core.ts
@@ -11,6 +11,13 @@ export type CoreErrors = {
       name?: string;
     }>;
 
+    // 最新のログファイルが存在しない場合
+    missingLatestLog: ErrorMessageContent<{
+      name?: string;
+      container?: string;
+    }>;
+
+
     // ポート番号が既に使用中
     serverPortIsUsed: ErrorMessageContent<{
       port: number;

--- a/src-electron/util/gz.ts
+++ b/src-electron/util/gz.ts
@@ -1,0 +1,34 @@
+// GZIP圧縮に関するutil
+import { Failable } from "../schema/error";
+import { BytesData } from "./bytesData";
+import { isError } from "./error/error";
+import { Path } from "./path";
+import * as zlib from "zlib"
+
+export class gzip {
+
+    // ファイルからgzipを生成
+    static async fromFile(path: Path): Promise<Failable<BytesData>> {
+        const content = await path.read()
+        if (isError(content)) return content
+
+        return new Promise<Failable<BytesData>>((resolve, reject) => {
+            zlib.gzip(content.data, (err, binary) => {
+                if (err !== null) reject(err)
+                resolve(BytesData.fromBuffer(binary))
+            }
+            );
+        })
+    }
+
+    // BytesDataからgzipを生成
+    static async fromData(content: BytesData): Promise<Failable<BytesData>> {
+        return new Promise<Failable<BytesData>>((resolve, reject) => {
+            zlib.gzip(content.data, (err, binary) => {
+                if (err !== null) reject(err)
+                resolve(BytesData.fromBuffer(binary))
+            }
+            );
+        })
+    }
+}

--- a/src-electron/util/path.ts
+++ b/src-electron/util/path.ts
@@ -112,6 +112,11 @@ export class Path {
     await fs.writeFile(this.path, content);
   }
 
+  async appendText(content: string) {
+    await this.parent().mkdir(true);
+    await fs.appendFile(this.path, content);
+  }
+
   /** 同期書き込み(非推奨) */
   writeTextSync(content: string) {
     this.parent().mkdirSync(true);

--- a/src/components/MainLayout/WorldTab.vue
+++ b/src/components/MainLayout/WorldTab.vue
@@ -83,7 +83,8 @@ function selectWorldIdx() {
         />
         <div v-show="consoleStore.status(world.id) !== 'Stop'" class="absolute-top-right badge">
           <q-badge outline rounded style="background-color: #262626; aspect-ratio: 1;" >
-            <q-icon :name="assets.svg.systemLogo_filled(getCssVar('primary')?.replace('#', '%23'))" size="1rem" />
+            <q-icon v-if="consoleStore.status(world.id) === 'CheckLog'" name="notes" size="1rem" />
+            <q-icon v-else :name="assets.svg.systemLogo_filled(getCssVar('primary')?.replace('#', '%23'))" size="1rem" />
           </q-badge>
         </div>
       </q-avatar>

--- a/src/components/World/Console/OperationView.vue
+++ b/src/components/World/Console/OperationView.vue
@@ -24,10 +24,14 @@ async function reboot() {
   await window.API.invokeReboot(worldID)
   consoleStore.resetReboot(worldID)
 }
+
+function closeLog() {
+  consoleStore.initTab(mainStore.selectedWorldID, true)
+}
 </script>
 
 <template>
-  <div class="row q-mx-md" style="padding-top: 14px; padding-bottom: 14px;">
+  <div v-if="consoleStore.status(mainStore.selectedWorldID) !== 'CheckLog'" class="row q-mx-md" style="padding-top: 14px; padding-bottom: 14px;">
     <SsBtn
       dense
       is-capital
@@ -71,5 +75,17 @@ async function reboot() {
         />
       </template>
     </q-input>
+  </div>
+  
+  <div v-else class="row q-mx-md" style="padding-top: 14px; padding-bottom: 14px;">
+    <q-space />
+    <SsBtn
+      dense
+      is-capital
+      icon="close"
+      label="閉じる"
+      @click="closeLog"
+      class="q-py-sm"
+    />
   </div>
 </template>

--- a/src/components/World/Console/OperationView.vue
+++ b/src/components/World/Console/OperationView.vue
@@ -83,7 +83,7 @@ function closeLog() {
       dense
       is-capital
       icon="close"
-      label="閉じる"
+      :label="$t('general.close')"
       @click="closeLog"
       class="q-py-sm"
     />

--- a/src/components/World/Console/RunningView.vue
+++ b/src/components/World/Console/RunningView.vue
@@ -34,7 +34,7 @@ consoleStore.$subscribe((mutation, state) => {
   /> -->
 
   <q-virtual-scroll
-    v-if="consoleStore.status(mainStore.selectedWorldID) === 'Running'"
+    v-if="['Running', 'CheckLog'].includes(consoleStore.status(mainStore.selectedWorldID))"
     ref="virtualListRef"
     :items="consoleStore.console(mainStore.selectedWorldID)"
     v-slot="{ item }"

--- a/src/components/World/Console/StopView.vue
+++ b/src/components/World/Console/StopView.vue
@@ -23,8 +23,8 @@ async function showLog() {
   <div v-if="consoleStore.status(mainStore.selectedWorldID) === 'Stop'" class="justify-center column fit">
     <running-btn :text-font-size="1.5" class="btn" style="width: fit-content; margin: 0 auto;" />
     <ss-btn
-      label="直前のサーバログを表示"
-      width="14rem"
+      :label="$t('console.showLog')"
+      width="16rem"
       @click="showLog"
       style="font-size: 1rem; margin: 1rem auto;"
     />

--- a/src/components/World/Console/StopView.vue
+++ b/src/components/World/Console/StopView.vue
@@ -1,15 +1,33 @@
 <script setup lang="ts">
 import { useMainStore } from 'src/stores/MainStore';
 import { useConsoleStore } from 'src/stores/ConsoleStore';
+import { checkError } from 'src/components/Error/Error';
+import { tError } from 'src/i18n/utils/tFunc';
 import RunningBtn from '../HOME/RunningBtn.vue';
+import SsBtn from 'src/components/util/base/ssBtn.vue';
 
 const mainStore = useMainStore()
 const consoleStore = useConsoleStore()
+
+async function showLog() {
+  const logs = await window.API.invokeFetchLatestWorldLog(mainStore.selectedWorldID)
+  checkError(
+    logs,
+    l => consoleStore.setAllConsole(mainStore.selectedWorldID, l, 'CheckLog'),
+    e => tError(e)
+  )
+}
 </script>
 
 <template>
-  <div v-if="consoleStore.status(mainStore.selectedWorldID) === 'Stop'" class="justify-center row fit">
-    <running-btn :text-font-size="1.5" class="btn" />
+  <div v-if="consoleStore.status(mainStore.selectedWorldID) === 'Stop'" class="justify-center column fit">
+    <running-btn :text-font-size="1.5" class="btn" style="width: fit-content; margin: 0 auto;" />
+    <ss-btn
+      label="直前のサーバログを表示"
+      width="14rem"
+      @click="showLog"
+      style="font-size: 1rem; margin: 1rem auto;"
+    />
   </div>
 </template>
 

--- a/src/components/World/HOME/RunningBtn.vue
+++ b/src/components/World/HOME/RunningBtn.vue
@@ -25,7 +25,7 @@ function stopServer() {
     v-if="consoleStore.status(mainStore.world.id) !== 'Running'"
     free-width
     color="primary"
-    :disable="mainStore.errorWorlds.has(mainStore.world.id) || consoleStore.status(mainStore.world.id) === 'Ready'"
+    :disable="mainStore.errorWorlds.has(mainStore.world.id) || consoleStore.status(mainStore.world.id) !== 'Stop'"
     :to="to"
     @click="runServer"
     :style="{'height': `${3 ** (textFontSize + 0.1)}rem`}"

--- a/src/components/World/HeaderView.vue
+++ b/src/components/World/HeaderView.vue
@@ -10,7 +10,8 @@ const consoleStore = useConsoleStore()
 const statusColor = {
   'Stop': 'negative',
   'Ready': 'grey',
-  'Running': 'primary'
+  'Running': 'primary',
+  'CheckLog': 'grey'
 }
 </script>
 

--- a/src/i18n/en-US/Other/error.ts
+++ b/src/i18n/en-US/Other/error.ts
@@ -172,6 +172,9 @@ export const enUSError: MessageSchema['error'] = {
       invalidWorldId: {
         title: 'The specified world does not exist.',
       },
+      missingLatestLog:{
+        title: 'Previous server log does not exist',
+      },
       serverPortIsUsed: {
         title: 'The port number in use is specified as the server port',
         desc: 'Please change the port number from {port} at property \'server-port\'',

--- a/src/i18n/en-US/Other/general.ts
+++ b/src/i18n/en-US/Other/general.ts
@@ -1,6 +1,7 @@
 import { MessageSchema } from "src/boot/i18n";
 
 export const enUSGeneral:MessageSchema['general'] = {
+  close: 'Close',
   cancel: 'Cancel',
   delete: 'Delete',
   edit: 'Edit',

--- a/src/i18n/en-US/Pages/World/console.ts
+++ b/src/i18n/en-US/Pages/World/console.ts
@@ -5,6 +5,7 @@ export const enUSConsole:MessageSchema['console'] = {
   boot: 'BOOT {name}',
   booting: 'Booting {id} ({type})/{name}',
   abnormalEnd:'Terminated abnormally',
+  showLog: 'Show the previous server log',
   stop: {
     btn: 'close',
     withName: 'CLOSE {name}',

--- a/src/i18n/en-US/Pages/World/console.ts
+++ b/src/i18n/en-US/Pages/World/console.ts
@@ -20,6 +20,7 @@ export const enUSConsole:MessageSchema['console'] = {
     Stop: 'Stop',
     Ready: 'Ready',
     Running: 'Running',
+    CheckLog: 'Checking Log'
   },
   shutdownServer: 'Shutdowning server',
   command: 'Command',

--- a/src/i18n/ja/Other/error.ts
+++ b/src/i18n/ja/Other/error.ts
@@ -174,6 +174,9 @@ export const jaError: ErrorTranslationTypes & ErrorDialogTitles = {
       invalidWorldId: {
         title: '指定されたワールドが存在しません',
       },
+      missingLatestLog:{
+        title: '直前のサーバログが存在しません',
+      },
       serverPortIsUsed: {
         title: '指定された番号のポートは使用中です',
         desc: 'プロパティ\'server-port\'よりポート番号を{port}から変更してください',

--- a/src/i18n/ja/Other/general.ts
+++ b/src/i18n/ja/Other/general.ts
@@ -1,4 +1,5 @@
 export const jaGeneral = {
+  close: '閉じる',
   cancel: 'キャンセル',
   delete: '削除',
   edit: '編集',

--- a/src/i18n/ja/Pages/World/console.ts
+++ b/src/i18n/ja/Pages/World/console.ts
@@ -3,6 +3,7 @@ export const jaConsole = {
   boot: '{name} を起動',
   booting: '{id} ({type})/{name}を起動中',
   abnormalEnd:'サーバーが異常終了しました',
+  showLog: '直前のサーバログを表示',
   stop: {
     btn: '停止',
     withName: '{name} を停止',

--- a/src/i18n/ja/Pages/World/console.ts
+++ b/src/i18n/ja/Pages/World/console.ts
@@ -18,6 +18,7 @@ export const jaConsole = {
     Stop: '停止中',
     Ready: '準備中',
     Running: '起動中',
+    CheckLog: 'ログ確認中'
   },
   shutdownServer: 'サーバーをシャットダウン中',
   command: 'コマンドを入力',

--- a/src/stores/ConsoleStore.ts
+++ b/src/stores/ConsoleStore.ts
@@ -9,9 +9,10 @@ import { values } from 'src/scripts/obj';
 import { $T, tError } from 'src/i18n/utils/tFunc';
 
 type consoleData = { chunk: string, isError: boolean }
+type WorldStatus = 'Stop' | 'Ready' | 'Running' | 'CheckLog'
 interface WorldConsole {
   [id: WorldID]: {
-    status: 'Stop' | 'Ready' | 'Running',
+    status: WorldStatus,
     clickedStop: boolean,
     clickedReboot: boolean,
     console: consoleData[]
@@ -56,6 +57,14 @@ export const useConsoleStore = defineStore('consoleStore', {
     setConsole(worldID: WorldID, consoleLine: string, isError: boolean) {
       this._world[worldID].status = 'Running'
       if (consoleLine !== void 0) { this._world[worldID].console.push({ chunk: consoleLine, isError: isError }) }
+    },
+    /**
+     * 一括でコンソールの中身を登録する
+     */
+    setAllConsole(worldID: WorldID, consoleLines: string[], status: WorldStatus) {
+      this._world[worldID].status = status
+      this._world[worldID].console = []
+      consoleLines.forEach(l => this._world[worldID].console.push({ chunk: l, isError: false }))
     },
     /**
      * コンソールに行を追加する 


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# latest.logの内容を取得する機能を追加

ワールドごとの最新の起動ログを取得する`API.invokeFetchLatestLog(world:WorldID)`を追加
Minecraft本体のロガーが起動する前にJavaが終了した場合には標準出力の内容をlatest.logに保存

## 変更箇所
#### backend
- [x] `API.invokeFetchLatestLog(world:WorldID)`を追加
- [x] Minecraft本体のロガーが起動する前にJavaが終了した場合には標準出力の内容をlatest.logに保存

#### frontend
- [x] @CivilTT ログ取得のGUIを整備
- [x] @nozz-mat 追加エラーの翻訳


<!--
## 承認者への申し送り事項

- 申し送り事項を記載しておく必要がある場合に追記する

-->