### PR TITLE
✨ 環境変数SERVERSTARTER_MODEが"debug"だった場合はリリースの取得元を変更

### DIFF
--- a/src-electron/updater/fetch.ts
+++ b/src-electron/updater/fetch.ts
@@ -3,12 +3,18 @@ import { BytesData } from '../util/bytesData';
 import { errorMessage } from '../util/error/construct';
 import { isError } from '../util/error/error';
 
-const SERVERSTARTER_REPOSITORY_URL =
-  'https://api.github.com/repos/CivilTT/ServerStarter2/releases';
-
 /** githubからリリース番号を取得 */
 export async function getLatestRelease(): Promise<Failable<GithubRelease>> {
+
+  // 環境変数SERVERSTARTER_MODEが"debug"だった場合はリリースの取得元を変更
+  const isDebug = process.env.SERVERSTARTER_MODE === "debug"
+
+  const SERVERSTARTER_REPOSITORY_URL = isDebug ?
+    'https://api.github.com/repos/CivilTT/ServerStarter2-ReleaseTest/releases' :
+    'https://api.github.com/repos/CivilTT/ServerStarter2/releases';
+
   const fetch = await BytesData.fromURL(SERVERSTARTER_REPOSITORY_URL);
+
   if (isError(fetch)) return fetch;
   const json = await fetch.json<GithubReleaseResponce[]>();
   if (isError(json)) return json;

--- a/src-electron/updater/updater.ts
+++ b/src-electron/updater/updater.ts
@@ -14,7 +14,7 @@ import { getSystemVersion } from './version';
  */
 async function checkUpdate() {
   const currentVersion = await getSystemVersion();
-  const latestRelease = await getLatestRelease();
+  const latestRelease = await getLatestRelease(osPlatform);
   // アップデートの取得に失敗
   if (isError(latestRelease)) return latestRelease;
   // アップデートなし
@@ -33,11 +33,11 @@ export async function update() {
   const update = await checkUpdate();
   logger.info(update);
 
-  
+
   if (update === false) {
     return;
   }
-  
+
   if (isError(update)) {
     return;
   }
@@ -47,8 +47,8 @@ export async function update() {
   sys.system.lastUpdatedTime = undefined;
   await setSystemSettings(sys);
 
-  if (osPlatform === 'windows-x64') await installWindows(update.windows);
+  if (osPlatform === 'windows-x64') await installWindows(update.url);
   if (osPlatform === 'mac-os' || osPlatform === 'mac-os-arm64')
-    await installMac(update.mac);
+    await installMac(update.url);
   logger.success();
 }


### PR DESCRIPTION

自動アップデートの検証用にリリースの取得元を変更できる機能を追加。

システムの環境変数SERVERSTARTER_MODEがdebugだった場合はリリースの取得元が
`https://api.github.com/repos/CivilTT/ServerStarter2/releases`
に変更されます。