### PR TITLE
🩹 サーバーの標準出力の内容でlatest.logを上書き

### DIFF
--- a/src-electron/core/world/loghandler.ts
+++ b/src-electron/core/world/loghandler.ts
@@ -55,7 +55,7 @@ export class WorldLogHandler {
     }
 
     /** 
-     * latest.logが存在しない場合は一時記録用のログファイルの内容をlatest.logとし、一時記録用のログファイルをリセット
+     * latest.logを削除し、一時記録用のログファイルの内容をlatest.logとする
      */
     async flash() {
         const tmp = await this.tempPath.get()
@@ -64,10 +64,10 @@ export class WorldLogHandler {
         const latest = this.LatestLogPath
 
         if (!latest.exists()) {
-            tmp.moveTo(latest)
-        } else {
-            tmp.remove()
+            await latest.remove()
         }
+
+        await tmp.moveTo(latest)
     }
 
     /** latest.logの内容を取得 */


### PR DESCRIPTION
MohistMc等のサーバーが出力するlatest.logの内容にエラー等が記されておらず、不具合の特定が困難であるため、
サーバーの標準出力の内容でlatest.logを上書きする仕様とした。

# 確認方法
windowsでmohistmc 1.18.2 ビルド137 で起動するとエラーで落ちるのでその際のログの内容を比較してください。