### PR TITLE
✨ 環境変数SERVERSTARTER_MODEが"noupdate"の場合自動アップデートを無効化

### DIFF
--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -22,7 +22,7 @@ try {
       path.join(app.getPath('userData'), 'DevTools Extensions')
     );
   }
-} catch (_) {}
+} catch (_) { }
 
 let mainWindow: BrowserWindow | undefined;
 
@@ -31,8 +31,8 @@ async function createWindow() {
    * Initial window options
    */
 
-  // ビルド版の場合アップデートをチェック
-  if (!process.env.DEBUGGING) {
+  // ビルド版 かつ 環境変数SERVERSTARTER_MODEがnoupdateでない 場合アップデートをチェック
+  if (!process.env.DEBUGGING && process.env.SERVERSTARTER_MODE !== "noupdate") {
     await update();
   }
 


### PR DESCRIPTION
デバッグ時に自動アプデーとがループする問題の解決として以下の機能を追加

- 環境変数SERVERSTARTER_MODEが"noupdate"の場合自動アップデートを無効化

SERVERSTARTER_MODEの値に応じて
- debug : デバッグ用リポジトリからアップデート内容を取得
- noupdate : 自動アップデートなし
- [それ以外] : 通常リポジトリからアップデート内容を取得

という挙動をする