### PR TITLE
NgrokTokenを設定していない場合ワールドのUseNgrokを無視

### DIFF
--- a/src-electron/core/fixers/ngrok.ts
+++ b/src-electron/core/fixers/ngrok.ts
@@ -2,6 +2,6 @@ import { NgrokSetting } from "app/src-electron/schema/ngrok";
 import { Fixer, booleanFixer, objectFixer, optionalFixer, stringFixer } from "app/src-electron/util/detaFixer/fixer";
 
 export const ngrok_settingFixer: Fixer<NgrokSetting> = objectFixer({
-    use_ngrok: booleanFixer(false),
+    use_ngrok: booleanFixer(true),
     remote_addr: optionalFixer(stringFixer())
 }, true)

--- a/src-electron/core/fixers/ngrok.ts
+++ b/src-electron/core/fixers/ngrok.ts
@@ -2,6 +2,6 @@ import { NgrokSetting } from "app/src-electron/schema/ngrok";
 import { Fixer, booleanFixer, objectFixer, optionalFixer, stringFixer } from "app/src-electron/util/detaFixer/fixer";
 
 export const ngrok_settingFixer: Fixer<NgrokSetting> = objectFixer({
-    use_ngrok: booleanFixer(true),
+    use_ngrok: booleanFixer(false),
     remote_addr: optionalFixer(stringFixer())
 }, true)

--- a/src-electron/core/world/handler.ts
+++ b/src-electron/core/world/handler.ts
@@ -746,8 +746,8 @@ export class WorldHandler {
   /**
    * 使用ポートを決定
    */
-  private async definePortNumber(beforeWorld: World): Promise<Failable<number>> {
-    if (beforeWorld.ngrok_setting.use_ngrok) {
+  private async definePortNumber(beforeWorld: World, ngrokToken: string | undefined): Promise<Failable<number>> {
+    if (beforeWorld.ngrok_setting.use_ngrok && ngrokToken) {
       // Ngrokを使用する場合 開いてるポートを適当に使う
       const portnum = await this.getFreePort()
       if (isError(portnum)) return portnum
@@ -819,7 +819,7 @@ export class WorldHandler {
     const savePath = this.getSavePath();
 
     // ポート番号を取得
-    const port = await this.definePortNumber(beforeWorld)
+    const port = await this.definePortNumber(beforeWorld, sysSettings.user.ngrokToken)
     if (isError(port)) return withError(port, errors)
 
     // 実行時のサーバープロパティ(ポートだけ違う)

--- a/src/components/World/HOME/Others/Ngrok/NgrokSettingDialog.vue
+++ b/src/components/World/HOME/Others/Ngrok/NgrokSettingDialog.vue
@@ -12,11 +12,19 @@ defineEmits({...useDialogPluginComponent.emitsObject})
 const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent()
 const prop = defineProps<NgrokDialogProp>()
 
-const authToken = ref(prop.token)
-const step = ref(prop.token !== '' ? 3 : 1)
+const step3Model: Ref<NgrokDialogReturns> = ref({
+  token: prop.token,
+  isAllUesNgrok: false
+})
+const isRegisteredNgrok = prop.token !== ''
+const step = ref(isRegisteredNgrok ? 3 : 1)
 const stepper: Ref<QStepper | undefined> = ref()
 const isSkipRegister = ref(false)
-const isRegisteredNgrok = prop.token !== ''
+
+// 一番最初の設定の際のみは初期値をTrueにする
+if (!isRegisteredNgrok) {
+  step3Model.value.isAllUesNgrok = true
+}
 </script>
 
 <template>
@@ -62,7 +70,7 @@ const isRegisteredNgrok = prop.token !== ''
             :title="$t('home.ngrok.dialog.thirdPage.title')"
             prefix="3"
           >
-            <Step3View v-model="authToken" />
+            <Step3View v-model="step3Model" />
           </q-step>  
         </q-stepper>
       </template>
@@ -81,10 +89,10 @@ const isRegisteredNgrok = prop.token !== ''
           outline
           :label="step === 3 ? $t('home.ngrok.dialog.save') : $t('home.ngrok.dialog.goNext')"
           color="primary"
-          :disable="step === 3 && authToken === ''"
+          :disable="step === 3 && step3Model.token === ''"
           @click="
             step === 3
-              ? onDialogOK({ token: authToken } as NgrokDialogReturns)
+              ? onDialogOK(step3Model)
               : stepper?.next()
           "
         />

--- a/src/components/World/HOME/Others/Ngrok/steps/Step3View.vue
+++ b/src/components/World/HOME/Others/Ngrok/steps/Step3View.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import { NgrokDialogReturns } from './iNgrok';
 import SsA from 'src/components/util/base/ssA.vue';
 import SsInput from 'src/components/util/base/ssInput.vue';
 
-const authToken = defineModel<string>({ required: true })
+const model = defineModel<NgrokDialogReturns>({ required: true })
 </script>
 
 <template>
@@ -20,9 +21,16 @@ const authToken = defineModel<string>({ required: true })
       </i18n-t>
     </p>
     <SsInput
-      v-model="authToken"
+      v-model="model.token"
       :placeholder="$t('home.ngrok.dialog.thirdPage.inputToken')"
       secret
-    />  
+    />
+
+    <q-checkbox
+      v-model="model.isAllUesNgrok"
+      :label="$t('home.ngrok.dialog.thirdPage.checkbox')"
+      class="q-pt-lg"
+      style="font-size: 1rem;"
+    />
   </div>
 </template>

--- a/src/components/World/HOME/Others/Ngrok/steps/iNgrok.ts
+++ b/src/components/World/HOME/Others/Ngrok/steps/iNgrok.ts
@@ -6,6 +6,7 @@ export interface NgrokDialogProp {
 
 export interface NgrokDialogReturns {
   token: string
+  isAllUesNgrok: boolean
 }
 
 export interface ImgDialogProp {

--- a/src/components/World/HOME/Others/NgrokView.vue
+++ b/src/components/World/HOME/Others/NgrokView.vue
@@ -22,6 +22,9 @@ function onClick() {
     } as NgrokDialogProp,
   }).onOk((p: NgrokDialogReturns) => {
     sysStore.systemSettings.user.ngrokToken = p.token;
+    if (p.isAllUesNgrok) {
+      mainStore.processAllWorld(w => w.ngrok_setting.use_ngrok = true)
+    }
   });
 }
 </script>

--- a/src/i18n/en-US/Pages/World/home.ts
+++ b/src/i18n/en-US/Pages/World/home.ts
@@ -87,7 +87,8 @@ export const enUSHome: MessageSchema['home'] = {
         Open {1} and input the displayed token below.\
         ',
         link: 'page to get an authentication token',
-        inputToken: 'Input Token'
+        inputToken: 'Input Token',
+        checkbox: 'Using this feature for all world',
       },
       goNext: 'Go next setting',
       save: 'Save your registration',

--- a/src/i18n/ja/Pages/World/home.ts
+++ b/src/i18n/ja/Pages/World/home.ts
@@ -86,6 +86,7 @@ export const jaHome = {
         ',
         link: '認証トークンを取得するウェブページ',
         inputToken: 'トークンを入力',
+        checkbox: 'すべてのワールドに対してNgrokを利用する',
       },
       goNext: '次の設定へ進む',
       save: '登録内容を保存',

--- a/src/stores/MainStore.ts
+++ b/src/stores/MainStore.ts
@@ -11,6 +11,7 @@ import { useSystemStore } from './SystemStore';
 import { useConsoleStore } from './ConsoleStore';
 import { assets } from 'src/assets/assets';
 import { tError } from 'src/i18n/utils/tFunc';
+import { values } from 'src/scripts/obj';
 
 export const useMainStore = defineStore('mainStore', {
   state: () => {
@@ -127,6 +128,15 @@ export const useMainStore = defineStore('mainStore', {
     updateWorld(world: World | WorldEdited) {
       const worldStore = useWorldStore()
       worldStore.worldList[world.id] = world
+    },
+    /**
+     * すべてのワールドに対してprocessで指定した処理を行う
+     */
+    processAllWorld(process: (world: WorldEdited) => void) {
+      const worldStore = useWorldStore()
+      values(worldStore.worldList).forEach(
+        w => process(w)
+      )
     },
     /**
      * Ngrokより割り当てられたIPアドレスを削除する（サーバー終了時を想定）

--- a/src/stores/MainStore.ts
+++ b/src/stores/MainStore.ts
@@ -134,9 +134,19 @@ export const useMainStore = defineStore('mainStore', {
      */
     processAllWorld(process: (world: WorldEdited) => void) {
       const worldStore = useWorldStore()
-      values(worldStore.worldList).forEach(
-        w => process(w)
-      )
+      values(worldStore.worldList).forEach(w => {
+        process(w)
+        
+        // App.vueのSubscriberは表示中のワールドに対する更新を行うため，
+        // 非表示ワールドの更新は別途ここで作動させる
+        window.API.invokeSetWorld(toRaw(w)).then(v => {
+          checkError(
+            v.value,
+            undefined,
+            e => tError(e)
+          )
+        })
+      });
     },
     /**
      * Ngrokより割り当てられたIPアドレスを削除する（サーバー終了時を想定）


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# NgrokTokenを設定していない場合ワールドのUseNgrokを無視

<!-- Pull Requestの概要を２行程度で説明する -->
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

#92 のHotfix
NgrokTokenがない場合でもワールドのUseNgrokの設定が効いていたので無効化
UseNgrokは追加設定の立ち位置なので初期値をfalseと改めた

Close #92 

## 確認方法
- settings.ssconfigを削除
- Ngrokの設定をせずにワールドを起動
- ポート番号が指定したもの(デフォルトの場合25565)であることを確認

<!--
## 承認者への申し送り事項

- 申し送り事項を記載しておく必要がある場合に追記する

-->
