### PR TITLE
forgeのダウンロードurlを修正

### DIFF
--- a/src-electron/core/fixers/version.ts
+++ b/src-electron/core/fixers/version.ts
@@ -44,6 +44,7 @@ export const fixForgeVersion = objectFixer<ForgeVersion>(
     id: stringFixer(),
     type: literalFixer(['forge']),
     forge_version: stringFixer(),
+    download_url: stringFixer(),
   },
   false
 );

--- a/src-electron/schema/version.ts
+++ b/src-electron/schema/version.ts
@@ -18,11 +18,12 @@ export type AllSpigotVersion = { id: string }[];
 export type PapermcVersion = { id: string; type: 'papermc'; build: number };
 export type AllPapermcVersion = { id: string; builds: number[] }[];
 
-export type ForgeVersion = { id: string; type: 'forge'; forge_version: string };
+export type ForgeVersion = { id: string; type: 'forge'; forge_version: string, download_url: string };
+
 export type AllForgeVersion = {
   id: string;
-  forge_versions: string[];
-  recommended?: string;
+  forge_versions: { version: string, url: string }[];
+  recommended?: { version: string, url: string };
 }[];
 
 export type MohistmcVersion = {


### PR DESCRIPTION
1.10以前のforgeがインストールできない問題を修正

それにあたり ForgeVersion / AllForgeVersion の型にurlの情報を加えた

@CivilTT フロントエンドも変更してしまったので、変更が正しいか確認してもらえると助かる
問題なく動いていそうなことは確認済

Close #25

## 検証方法
1.10以前のforgeのインストールに成功すればOK

## 備考
forgeのバージョンごとにまた別の不具合が出てるので注意

1.20 : 正常起動
1.18 : 正常起動
1.16.1 : 正常起動
1.14.2 : 起動するがコンソール入力不可 (停止再起動不可)
1.12 : クライアントインストール不可により未検証
1.10: 正常起動
1.8: Eulaがない場合に自動終了しない & -noguiが効かない
1.6.1: 全部のログがエラー出力で帰ってくる
1.5.2: 起動不可